### PR TITLE
Add modular packing utilities and benchmarks for all tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__
+.vscode
+*.pyc
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -364,6 +364,29 @@ result = extractor.extract_json(
 # }
 ```
 
+## ⚡ Accelerating Inference with Sequence Packing
+
+Pack multiple short requests into a single transformer pass with a block-diagonal attention mask to cut padding overhead and boost throughput.
+
+```python
+from gliner2 import GLiNER2, InferencePackingConfig
+
+extractor = GLiNER2.from_pretrained("your-model", map_location="cuda")
+packing_cfg = InferencePackingConfig(
+    max_length=512,
+    sep_token_id=extractor.processor.tokenizer.sep_token_id,
+    streams_per_batch=1,
+)
+
+# Configure once for all subsequent calls (override per call if needed)
+extractor.configure_inference_packing(packing_cfg)
+
+texts = ["Email CEO to approve budget", "Schedule yearly medical checkup"]
+labels = ["person", "organization", "action"]
+
+results = extractor.batch_extract_entities(texts, labels, batch_size=16)
+```
+
 ## 📄 License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/gliner2/__init__.py
+++ b/gliner2/__init__.py
@@ -2,3 +2,9 @@ __version__ = "1.0.2"
 
 from .inference.engine import GLiNER2, RegexValidator
 from .model import Extractor, ExtractorConfig
+from .infer_packing import (
+    InferencePackingConfig,
+    PackedBatch,
+    pack_requests,
+    unpack_spans,
+)

--- a/gliner2/infer_packing.py
+++ b/gliner2/infer_packing.py
@@ -1,0 +1,233 @@
+"""Utilities for inference-time sequence packing with block-diagonal masks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+
+
+@dataclass
+class InferencePackingConfig:
+    """Configuration describing how sequences should be packed."""
+
+    max_length: int
+    sep_token_id: Optional[int] = None
+    streams_per_batch: int = 1
+
+
+@dataclass
+class PackedBatch:
+    """Container describing a packed collection of requests."""
+
+    input_ids: torch.LongTensor
+    attention_mask: torch.LongTensor
+    pair_attention_mask: torch.BoolTensor
+    segment_ids: torch.LongTensor
+    map_out: List[List[int]]
+    offsets: List[List[int]]
+    lengths: List[List[int]]
+
+
+Request = Dict[str, Any]
+
+
+def _ensure_list(tokens: Sequence[int]) -> List[int]:
+    if isinstance(tokens, list):
+        return tokens
+    return [int(t) for t in tokens]
+
+
+def block_diag_mask(segment_ids: torch.LongTensor) -> torch.BoolTensor:
+    """Construct a block diagonal mask from per-token segment ids."""
+
+    return segment_ids.unsqueeze(2).eq(segment_ids.unsqueeze(1))
+
+
+def _pad_2d(x: torch.Tensor, target: int, pad_val: int) -> torch.Tensor:
+    if x.size(1) >= target:
+        return x
+    out = x.new_full((x.size(0), target), pad_val)
+    out[:, : x.size(1)] = x
+    return out
+
+
+class _PackedStream:
+    __slots__ = ("tokens", "map_out", "offsets", "lengths")
+
+    def __init__(self) -> None:
+        self.tokens: List[int] = []
+        self.map_out: List[int] = []
+        self.offsets: List[int] = []
+        self.lengths: List[int] = []
+
+    @property
+    def total_tokens(self) -> int:
+        return len(self.tokens)
+
+    def append(self, req_idx: int, tokens: Sequence[int]) -> None:
+        offset = self.total_tokens
+        segment_tokens = _ensure_list(tokens)
+        self.tokens.extend(segment_tokens)
+        self.map_out.append(req_idx)
+        self.offsets.append(offset)
+        self.lengths.append(len(segment_tokens))
+
+
+def _prepare_streams(requests: List[Request], cfg: InferencePackingConfig) -> List[_PackedStream]:
+    if cfg.streams_per_batch < 1:
+        raise ValueError("streams_per_batch must be >= 1")
+
+    streams: List[_PackedStream] = []
+
+    for req_idx, request in enumerate(requests):
+        tokens = request.get("input_ids")
+        if tokens is None:
+            raise KeyError("Each request must provide an 'input_ids' entry")
+        token_list = _ensure_list(tokens)
+        if cfg.max_length <= 0:
+            raise ValueError("max_length must be positive")
+        if len(token_list) > cfg.max_length:
+            token_list = token_list[: cfg.max_length]
+
+        placed = False
+        for stream in streams:
+            if stream.total_tokens + len(token_list) <= cfg.max_length:
+                stream.append(req_idx, token_list)
+                placed = True
+                break
+
+        if not placed:
+            stream = _PackedStream()
+            stream.append(req_idx, token_list)
+            streams.append(stream)
+
+    return streams
+
+
+def _build_segment_ids(streams: List[_PackedStream], max_len: int) -> torch.LongTensor:
+    segment_rows: List[torch.Tensor] = []
+    for stream in streams:
+        seg = torch.zeros(max_len, dtype=torch.long)
+        seg_id = 1
+        for offset, length in zip(stream.offsets, stream.lengths):
+            if length == 0:
+                continue
+            seg[offset : offset + length] = seg_id
+            seg_id += 1
+        segment_rows.append(seg)
+    if not segment_rows:
+        return torch.zeros((0, max_len), dtype=torch.long)
+    return torch.stack(segment_rows, dim=0)
+
+
+def pack_requests(requests: List[Request], cfg: InferencePackingConfig, pad_token_id: int) -> PackedBatch:
+    """Pack a collection of requests into one or more streams."""
+
+    if not isinstance(requests, list):
+        requests = list(requests)
+    if len(requests) == 0:
+        raise ValueError("Expected at least one request to pack")
+
+    streams = _prepare_streams(requests, cfg)
+
+    max_len = max((stream.total_tokens for stream in streams), default=cfg.max_length)
+    if max_len == 0:
+        max_len = 1
+
+    input_rows = []
+    mask_rows = []
+    for stream in streams:
+        ids = torch.tensor(stream.tokens, dtype=torch.long)
+        input_rows.append(_pad_2d(ids.unsqueeze(0), max_len, pad_token_id).squeeze(0))
+        mask = torch.ones(len(stream.tokens), dtype=torch.long)
+        mask_rows.append(_pad_2d(mask.unsqueeze(0), max_len, 0).squeeze(0))
+
+    if input_rows:
+        input_ids = torch.stack(input_rows, dim=0)
+        attention_mask = torch.stack(mask_rows, dim=0)
+    else:
+        input_ids = torch.full((0, max_len), pad_token_id, dtype=torch.long)
+        attention_mask = torch.zeros((0, max_len), dtype=torch.long)
+
+    segment_ids = _build_segment_ids(streams, max_len)
+
+    if attention_mask.numel() == 0:
+        pair_mask = torch.zeros((segment_ids.size(0), max_len, max_len), dtype=torch.bool)
+    else:
+        pair_mask = block_diag_mask(segment_ids)
+        attn_b = attention_mask.to(torch.bool)
+        pair_mask = pair_mask & attn_b.unsqueeze(2) & attn_b.unsqueeze(1)
+
+    map_out = [list(stream.map_out) for stream in streams]
+    offsets = [list(stream.offsets) for stream in streams]
+    lengths = [list(stream.lengths) for stream in streams]
+
+    return PackedBatch(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        pair_attention_mask=pair_mask,
+        segment_ids=segment_ids,
+        map_out=map_out,
+        offsets=offsets,
+        lengths=lengths,
+    )
+
+
+def _resolve_backend_tensor(tensor_like: Any) -> torch.Tensor:
+    if isinstance(tensor_like, torch.Tensor):
+        return tensor_like
+    try:
+        import numpy as np
+    except ModuleNotFoundError as exc:
+        raise TypeError("Unsupported tensor type without NumPy installed") from exc
+
+    if isinstance(tensor_like, np.ndarray):
+        return torch.from_numpy(tensor_like)
+
+    raise TypeError(f"Unsupported tensor type: {type(tensor_like)!r}")
+
+
+def unpack_spans(per_token_outputs: Any, packed: PackedBatch) -> List[Any]:
+    """Unpack encoder outputs back to the original request layout."""
+
+    tensor = _resolve_backend_tensor(per_token_outputs)
+    if tensor.dim() < 2:
+        raise ValueError("per_token_outputs must be at least 2-dimensional")
+
+    num_requests = 0
+    for stream_map in packed.map_out:
+        for req_idx in stream_map:
+            num_requests = max(num_requests, req_idx + 1)
+
+    outputs: List[List[torch.Tensor]] = [[] for _ in range(num_requests)]
+
+    for stream_idx, req_indices in enumerate(packed.map_out):
+        offsets = packed.offsets[stream_idx]
+        lengths = packed.lengths[stream_idx]
+        for seg_idx, req_idx in enumerate(req_indices):
+            length = lengths[seg_idx]
+            offset = offsets[seg_idx]
+            if length == 0:
+                segment = tensor.new_zeros((0,) + tensor.shape[2:])
+            else:
+                segment = tensor[stream_idx, offset : offset + length]
+            outputs[req_idx].append(segment)
+
+    merged: List[Any] = []
+    for parts in outputs:
+        if not parts:
+            merged.append(tensor.new_zeros((0,) + tensor.shape[2:]))
+        elif len(parts) == 1:
+            merged.append(parts[0])
+        else:
+            merged.append(torch.cat(parts, dim=0))
+
+    if isinstance(per_token_outputs, torch.Tensor):
+        return merged
+
+    np_outputs: List[Any] = []
+    for item in merged:
+        np_outputs.append(item.cpu().numpy())
+    return np_outputs

--- a/gliner2/packing_utils.py
+++ b/gliner2/packing_utils.py
@@ -1,0 +1,178 @@
+from typing import Optional, Dict, Any
+
+import torch
+from transformers.modeling_outputs import BaseModelOutput
+
+
+def build_position_ids(packed) -> torch.Tensor:
+    """Build position_ids that reset at each packed segment."""
+    position_ids = torch.zeros_like(packed.input_ids)
+    for row, (offsets, lengths) in enumerate(zip(packed.offsets, packed.lengths)):
+        for offset, length in zip(offsets, lengths):
+            if length > 0:
+                position_ids[row, offset:offset + length] = torch.arange(
+                    length, device=position_ids.device, dtype=position_ids.dtype
+                )
+    return position_ids
+
+
+def _get_model_dtype(encoder) -> torch.dtype:
+    try:
+        return next(encoder.parameters()).dtype
+    except StopIteration:
+        return torch.float32
+
+
+def _prepare_pair_attention_masks(
+        pair_attention_mask: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        input_ids: Optional[torch.Tensor],
+        inputs_embeds: Optional[torch.Tensor],
+        encoder
+) -> dict:
+    device = pair_attention_mask.device
+    if input_ids is not None:
+        device = input_ids.device
+    elif inputs_embeds is not None:
+        device = inputs_embeds.device
+
+    pair_mask_bool = pair_attention_mask.to(device=device, dtype=torch.bool)
+
+    token_mask_bool = pair_mask_bool.any(dim=-1)
+    if attention_mask is not None:
+        token_mask_bool = token_mask_bool & attention_mask.to(device=device, dtype=torch.bool)
+
+    seq_len = pair_mask_bool.size(-1)
+    if seq_len:
+        identity = torch.eye(seq_len, device=device, dtype=torch.bool).unsqueeze(0)
+        token_diag = token_mask_bool.unsqueeze(-1)
+        pair_mask_bool = pair_mask_bool | (identity & token_diag)
+
+    active = token_mask_bool.unsqueeze(-1) & token_mask_bool.unsqueeze(-2)
+    pair_mask_bool = pair_mask_bool & active
+
+    if attention_mask is not None:
+        token_mask = token_mask_bool.to(attention_mask.dtype)
+    else:
+        token_mask = token_mask_bool.to(dtype=torch.float32)
+
+    mask_dtype = _get_model_dtype(encoder)
+    neg_inf = torch.finfo(mask_dtype).min
+    extended_mask = torch.zeros(
+        pair_mask_bool.shape, dtype=mask_dtype, device=device
+    ).masked_fill(~pair_mask_bool, neg_inf).unsqueeze(1)
+
+    inactive = ~token_mask_bool
+    if inactive.any():
+        extended_mask = extended_mask.masked_fill(
+            inactive.unsqueeze(1).unsqueeze(-1),
+            torch.tensor(0.0, dtype=mask_dtype, device=device),
+        )
+
+    return {
+        "token_mask": token_mask,
+        "token_mask_bool": token_mask_bool,
+        "extended_mask": extended_mask,
+        "block_mask": pair_mask_bool,
+    }
+
+
+def _forward_deberta(
+        encoder,
+        input_ids: Optional[torch.Tensor],
+        model_kwargs: Dict[str, Any],
+        mask_info: dict,
+) -> BaseModelOutput:
+    inputs_embeds = model_kwargs.pop("inputs_embeds", None)
+    token_type_ids = model_kwargs.pop("token_type_ids", None)
+    position_ids = model_kwargs.pop("position_ids", None)
+    output_attentions = model_kwargs.pop("output_attentions")
+    produce_hidden = model_kwargs.pop("output_hidden_states")
+    return_dict = model_kwargs.pop("return_dict")
+
+    if input_ids is None and inputs_embeds is None:
+        raise ValueError("Either input_ids or inputs_embeds must be provided for packed attention")
+    if input_ids is not None and inputs_embeds is not None:
+        raise ValueError("Cannot supply both input_ids and inputs_embeds")
+
+    if token_type_ids is None:
+        ref = inputs_embeds if inputs_embeds is not None else input_ids
+        shape = ref.size()[:-1] if inputs_embeds is not None else ref.size()
+        token_type_ids = torch.zeros(shape, dtype=torch.long, device=ref.device)
+
+    embedding_output = encoder.embeddings(
+        input_ids=input_ids,
+        token_type_ids=token_type_ids,
+        position_ids=position_ids,
+        mask=mask_info["token_mask"],
+        inputs_embeds=inputs_embeds,
+    )
+
+    encoder_outputs = encoder.encoder(
+        embedding_output,
+        mask_info["block_mask"],
+        output_hidden_states=True,
+        output_attentions=output_attentions,
+        return_dict=True,
+    )
+
+    encoded_layers = list(encoder_outputs.hidden_states)
+    sequence_output = encoded_layers[-1]
+    hidden_states_tuple = tuple(encoded_layers) if produce_hidden else None
+    attentions = encoder_outputs.attentions if output_attentions else None
+
+    if not return_dict:
+        result = (sequence_output,)
+        if hidden_states_tuple is not None:
+            result += (hidden_states_tuple,)
+        if attentions is not None:
+            result += (attentions,)
+        return result
+
+    return BaseModelOutput(
+        last_hidden_state=sequence_output,
+        hidden_states=hidden_states_tuple,
+        attentions=attentions,
+    )
+
+
+def apply_pair_attention_encoder(
+        encoder,
+        packed_ids: torch.Tensor,
+        pair_mask: torch.Tensor,
+        fallback_mask: torch.Tensor,
+        position_ids: Optional[torch.Tensor] = None,
+        **kwargs,
+):
+    attn_to_use = pair_mask if pair_mask.numel() else fallback_mask
+
+    model_name = encoder.__class__.__name__.lower()
+    model_type = getattr(encoder.config, "model_type", "") or ""
+
+    if pair_mask.numel() and ("deberta" in model_name or "deberta" in model_type):
+        mask_info = _prepare_pair_attention_masks(
+            pair_mask,
+            fallback_mask,
+            packed_ids,
+            kwargs.get("inputs_embeds"),
+            encoder,
+        )
+        model_kwargs = dict(kwargs)
+        model_kwargs.setdefault("output_attentions", False)
+        model_kwargs.setdefault("output_hidden_states", False)
+        model_kwargs.setdefault("return_dict", True)
+        if position_ids is not None:
+            model_kwargs.setdefault("position_ids", position_ids)
+        return _forward_deberta(
+            encoder,
+            packed_ids if "input_ids" not in model_kwargs else model_kwargs.get("input_ids"),
+            model_kwargs,
+            mask_info,
+        )
+
+    return encoder(
+        input_ids=packed_ids,
+        attention_mask=attn_to_use,
+        position_ids=position_ids,
+        **kwargs,
+    )

--- a/tests/bench_gliner2_classification.py
+++ b/tests/bench_gliner2_classification.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+"""Compare GLiNER2 classification with and without inference packing."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+from typing import Dict, List, Sequence
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gliner2 import GLiNER2, InferencePackingConfig
+
+
+DEFAULT_TEXTS: List[str] = [
+    "This laptop has amazing performance but terrible battery life.",
+    "Customer support was quick and helpful.",
+    "The product arrived damaged and the packaging was awful.",
+    "Battery lasts all day, screen is bright, overall excellent value.",
+    "Mediocre camera, slow software updates, not worth the price.",
+    "Great noise cancellation and comfortable fit for long flights.",
+    "Sound quality is muddy and the mic is unusable for calls.",
+    "Fantastic build quality, but the keyboard feels cheap.",
+]
+
+DEFAULT_TASKS: Dict[str, List[str]] = {
+    "sentiment": ["positive", "neutral", "negative"],
+    "quality": ["high", "medium", "low"],
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run GLiNER2 classification with and without inference packing.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="fastino/gliner2-base-v1",
+        help="Model name or local path for GLiNER2.from_pretrained",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Device to run inference on (e.g. 'cpu', 'cuda', 'cuda:0')",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size for encoder forward passes",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Confidence threshold passed to GLiNER2",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Override maximum packed sequence length (defaults to model max position embeddings)",
+    )
+    parser.add_argument(
+        "--streams-per-batch",
+        type=int,
+        default=1,
+        help="Number of packed streams to generate per batch",
+    )
+    return parser.parse_args()
+
+
+def _sync_if_cuda(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _run_once(
+        extractor: GLiNER2,
+        *,
+        texts: Sequence[str],
+        tasks: Dict[str, List[str]],
+        batch_size: int,
+        threshold: float,
+        device: torch.device,
+        packing_config: InferencePackingConfig | None,
+) -> tuple[List[dict], float]:
+    _sync_if_cuda(device)
+    start = time.perf_counter()
+    preds = extractor.batch_classify_text(
+        list(texts),
+        tasks,
+        batch_size=batch_size,
+        threshold=threshold,
+        packing_config=packing_config,
+    )
+    _sync_if_cuda(device)
+    elapsed = time.perf_counter() - start
+    return preds, elapsed
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+
+    texts: List[str] = list(DEFAULT_TEXTS)
+    tasks: Dict[str, List[str]] = dict(DEFAULT_TASKS)
+
+    extractor = GLiNER2.from_pretrained(args.model, map_location=str(device))
+    extractor.to(device)
+    extractor.eval()
+
+    max_length = args.max_length
+    if max_length is None:
+        max_length = getattr(extractor.encoder.config, "max_position_embeddings", None)
+    if max_length is None:
+        raise ValueError("Unable to infer max sequence length for packing; please pass --max-length")
+
+    sep_token_id = getattr(extractor.processor.tokenizer, "sep_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "eos_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "pad_token_id", None)
+
+    packing_cfg = InferencePackingConfig(
+        max_length=int(max_length),
+        sep_token_id=sep_token_id,
+        streams_per_batch=args.streams_per_batch,
+    )
+
+    print("Running baseline (no packing)...")
+    baseline_preds, baseline_time = _run_once(
+        extractor,
+        texts=texts,
+        tasks=tasks,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=None,
+    )
+
+    print("Running with inference packing...")
+    packed_preds, packed_time = _run_once(
+        extractor,
+        texts=texts,
+        tasks=tasks,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=packing_cfg,
+    )
+
+    identical = baseline_preds == packed_preds
+
+    print("Timing summary:")
+    print(f"  Without packing: {baseline_time:.3f} s")
+    print(f"  With packing   : {packed_time:.3f} s")
+    if packed_time > 0:
+        print(f"  Speedup        : {baseline_time / packed_time:.2f}x")
+    print(f"Predictions identical: {identical}")
+
+    if not identical:
+        print("Baseline predictions:", baseline_preds)
+        print("Packed predictions   :", packed_preds)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_gliner2_e2e.py
+++ b/tests/bench_gliner2_e2e.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python
+"""Compare GLiNER2 predictions with and without inference packing."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+import requests
+from typing import List, Sequence
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gliner2 import GLiNER2, InferencePackingConfig
+
+
+DEFAULT_TEXTS: List[str] = [
+    "OpenAI launched GPT-4o in San Francisco, while Sam Altman discussed future plans on CNBC.",
+    "NASA announced that the Artemis II mission will send astronauts around the Moon in 2025.",
+    "Amazon acquired Whole Foods for $13.7 billion and expanded grocery delivery across the United States.",
+    "Taylor Swift kicked off her Eras Tour in Glendale before headlining shows across Europe in 2024.",
+    "Elon Musk unveiled Tesla’s Cybertruck at a launch event in Los Angeles in 2019.",
+    "Apple introduced the Vision Pro headset at WWDC 2023 in Cupertino.",
+    "Google I/O 2022 showcased advances in AI, including new features for Google Translate.",
+    "Lionel Messi signed with Inter Miami in 2023, changing the face of Major League Soccer in the United States.",
+    "The FIFA World Cup 2022 was held in Qatar, attracting millions of fans worldwide.",
+    "Meta rebranded from Facebook in October 2021 to emphasize its focus on the Metaverse.",
+    "Microsoft acquired Activision Blizzard in 2022 for nearly $69 billion, one of the largest deals in gaming history.",
+    "Serena Williams announced her retirement after the 2022 U.S. Open in New York.",
+    "The Paris Climate Agreement was signed in 2016, bringing together nations to fight global warming.",
+    "Pfizer and BioNTech developed the first widely distributed COVID-19 vaccine in 2020.",
+    "The 2008 financial crisis was triggered by the collapse of Lehman Brothers on Wall Street.",
+    "Barack Obama was elected President of the United States in 2008, becoming the first African-American president.",
+    "India landed Chandrayaan-3 on the lunar south pole in 2023, marking a historic achievement for ISRO.",
+    "The Nobel Peace Prize in 2014 was awarded to Malala Yousafzai for her fight for girls’ education.",
+    "Cristiano Ronaldo scored his 800th career goal during a match at Old Trafford in 2021.",
+    "The United Nations was founded in San Francisco in 1945 after World War II.",
+    "Beyoncé performed at Coachella 2018, an event later dubbed 'Beychella' by fans.",
+    "The Great Recession officially ended in June 2009 after massive stimulus spending.",
+    "Alibaba raised $25 billion in its 2014 IPO on the New York Stock Exchange.",
+    "Jeff Bezos stepped down as Amazon CEO in July 2021, handing over to Andy Jassy.",
+    "The Tokyo 2020 Olympics were postponed to 2021 due to the COVID-19 pandemic.",
+    "The Euro 2016 football championship was held across France, with Portugal emerging as the winner.",
+    "Netflix premiered 'Stranger Things' in 2016, a show that became a global pop culture phenomenon.",
+    "The iPhone was first introduced by Steve Jobs in January 2007 in San Francisco.",
+    "The Berlin Wall fell in 1989, symbolizing the end of the Cold War in Europe.",
+    "Queen Elizabeth II passed away in September 2022, ending the longest reign in British history.",
+    "Google acquired YouTube in 2006 for $1.65 billion, reshaping the digital media landscape.",
+]
+
+long_seq = """In 2023, OpenAI released GPT-4o at a major event in San Francisco, with CEO Sam Altman joining a panel on CNBC to discuss the company’s ambitions for artificial general intelligence. At nearly the same time, Google hosted its I/O conference in Mountain View, unveiling breakthroughs in translation and search while Sundar Pichai emphasized responsible AI. Meanwhile, Microsoft completed its $69 billion acquisition of Activision Blizzard, reshaping the gaming industry and prompting regulators in Brussels and Washington, D.C. to raise antitrust concerns.  
+
+Elsewhere, NASA announced that the Artemis II mission, scheduled for 2025, would send astronauts around the Moon for the first time in decades, while SpaceX prepared a Starship launch from Boca Chica, Texas. In Europe, the European Union finalized a sweeping AI Act in Brussels in 2024, hailed as the most comprehensive technology regulation since GDPR in 2018. At the same time, the United Nations hosted the COP28 climate summit in Dubai, where leaders including Emmanuel Macron, Narendra Modi, and Joe Biden pledged trillions of dollars in green investment.  
+
+In sports, Lionel Messi shocked the world by signing with Inter Miami in 2023 after leaving Paris Saint-Germain, while Cristiano Ronaldo continued his career with Al-Nassr in Saudi Arabia. The 2022 FIFA World Cup in Qatar had already set records for attendance and sponsorship revenue, with Adidas and Coca-Cola reporting billions in sales tied to the event. Meanwhile, the International Olympic Committee prepared for the Paris 2024 Summer Games, investing heavily in infrastructure projects across France.  
+
+On the cultural front, Taylor Swift’s Eras Tour began in Glendale in 2023 before expanding across Europe in 2024, generating over a billion dollars in ticket sales and boosting local economies from London to Berlin. Netflix, still riding the success of “Stranger Things” and “The Crown,” announced partnerships with South Korean studios in Seoul, investing $2.5 billion in new dramas by 2027. In Hollywood, the 2022 Academy Awards saw “CODA” win Best Picture, while the 2023 ceremony honored “Everything Everywhere All at Once,” with Michelle Yeoh becoming the first Asian woman to win Best Actress.  
+
+Meanwhile, in global finance, Bitcoin surged to an all-time high of $69,000 in November 2021 before crashing below $20,000 in 2022, causing turmoil for crypto exchanges like FTX, which filed for bankruptcy in Delaware after revelations about Sam Bankman-Fried’s empire. By 2024, BlackRock and Fidelity were filing ETF applications with the U.S. Securities and Exchange Commission, betting on mainstream adoption. In Asia, Alibaba and Tencent continued to expand their digital payment systems, while India’s UPI network processed more than 10 billion transactions in a single month.  
+
+Finally, political headlines dominated the world stage. In September 2022, Queen Elizabeth II passed away in Balmoral, prompting a global outpouring of grief and the accession of King Charles III. In the United States, the 2024 presidential race heated up with debates in Washington and rallies in key swing states like Pennsylvania, Michigan, and Arizona. Meanwhile, leaders gathered at the G20 Summit in New Delhi in 2023, where Prime Minister Narendra Modi welcomed counterparts from China, Japan, and the European Union, emphasizing collaboration in technology, trade, and climate resilience. Across all these events, the interplay of innovation, regulation, culture, and geopolitics underscored how interconnected the twenty-first century has become.
+"""
+DEFAULT_TEXTS.append(long_seq)
+
+DEFAULT_LABELS: List[str] = [
+    "Person",
+    "Organization",
+    "Location",
+    "Event",
+    "Date",
+    "Product",
+]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a GLiNER2 batch with and without inference packing.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="fastino/gliner2-base-v1",
+        help="Model name or local path for GLiNER2.from_pretrained",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Device to run inference on (e.g. 'cpu', 'cuda', 'cuda:0')",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size for encoder forward passes",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Confidence threshold passed to GLiNER2",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Override maximum packed sequence length (defaults to model max position embeddings)",
+    )
+    parser.add_argument(
+        "--streams-per-batch",
+        type=int,
+        default=1,
+        help="Number of packed streams to generate per batch",
+    )
+    return parser.parse_args()
+
+
+def _sync_if_cuda(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _run_once(
+        extractor: GLiNER2,
+        *,
+        texts: Sequence[str],
+        labels: Sequence[str],
+        batch_size: int,
+        threshold: float,
+        device: torch.device,
+        packing_config: InferencePackingConfig | None,
+) -> tuple[List[dict], float]:
+    _sync_if_cuda(device)
+    start = time.perf_counter()
+    preds = extractor.batch_extract_entities(
+        list(texts),
+        list(labels),
+        batch_size=batch_size,
+        threshold=threshold,
+        include_confidence=True,
+        packing_config=packing_config,
+    )
+    _sync_if_cuda(device)
+    elapsed = time.perf_counter() - start
+    return preds, elapsed
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+
+    texts: List[str] = list(DEFAULT_TEXTS)
+    labels: List[str] = list(DEFAULT_LABELS)
+
+    try:
+        extractor = GLiNER2.from_pretrained(args.model, map_location=str(device))
+    except requests.exceptions.RequestException as exc:  # pragma: no cover - network / I/O failures
+        raise SystemExit(
+            "Failed to load GLiNER2 model due to network error. "
+            "Pass --model with a local path or enable network access."
+        ) from exc
+    except Exception as exc:  # pragma: no cover - other load failures
+        raise SystemExit(
+            "Failed to load GLiNER2 model. Pass --model with a local path or ensure access."
+        ) from exc
+
+    extractor.to(device)
+    extractor.eval()
+
+    max_length = args.max_length
+    if max_length is None:
+        max_length = getattr(extractor.encoder.config, "max_position_embeddings", None)
+    if max_length is None:
+        raise ValueError("Unable to infer max sequence length for packing; please pass --max-length")
+
+    sep_token_id = getattr(extractor.processor.tokenizer, "sep_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "eos_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "pad_token_id", None)
+
+    packing_cfg = InferencePackingConfig(
+        max_length=int(max_length),
+        sep_token_id=sep_token_id,
+        streams_per_batch=args.streams_per_batch,
+    )
+
+    print("Running baseline (no packing)...")
+    baseline_preds, baseline_time = _run_once(
+        extractor,
+        texts=texts,
+        labels=labels,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=None,
+    )
+
+    print("Running with inference packing...")
+    packed_preds, packed_time = _run_once(
+        extractor,
+        texts=texts,
+        labels=labels,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=packing_cfg,
+    )
+
+    identical = baseline_preds == packed_preds
+
+    print("Timing summary:")
+    print(f"  Without packing: {baseline_time:.3f} s")
+    print(f"  With packing   : {packed_time:.3f} s")
+    if packed_time > 0:
+        print(f"  Speedup        : {baseline_time / packed_time:.2f}x")
+    print(f"Predictions identical: {identical}")
+
+    # Uncomment to inspect differences interactively
+    if not identical:
+        print("Baseline predictions:", baseline_preds)
+        print("Packed predictions:", packed_preds)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_gliner2_structured.py
+++ b/tests/bench_gliner2_structured.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""Compare GLiNER2 structured extraction with and without inference packing."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+from typing import Dict, List, Sequence
+
+import torch
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gliner2 import GLiNER2, InferencePackingConfig
+
+
+DEFAULT_TEXTS: List[str] = [
+    "iPhone 15 Pro Max with 256GB storage, A17 Pro chip, priced at $1199. Available in titanium and black colors.",
+    "Galaxy S24 priced at $899 with 512GB and Exynos chipset.",
+    "Pixel 8 available for $699 with 128GB and Google's Tensor G3.",
+    "MacBook Air M2 costs $1199 with 8GB RAM and 256GB SSD.",
+    "Dell XPS 13 sells for $999 with 16GB RAM and 512GB SSD.",
+]
+
+DEFAULT_STRUCTURES: Dict[str, List[str]] = {
+    "product": [
+        "name::str::Full product name and model",
+        "price::str::Product price with currency",
+        "storage::str::Storage capacity like 256GB or 1TB",
+        "chip::str::Processor information",
+    ]
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run GLiNER2 structured extraction with and without inference packing.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="fastino/gliner2-base-v1",
+        help="Model name or local path for GLiNER2.from_pretrained",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Device to run inference on (e.g. 'cpu', 'cuda', 'cuda:0')",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Batch size for encoder forward passes",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.5,
+        help="Confidence threshold passed to GLiNER2",
+    )
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=None,
+        help="Override maximum packed sequence length (defaults to model max position embeddings)",
+    )
+    parser.add_argument(
+        "--streams-per-batch",
+        type=int,
+        default=1,
+        help="Number of packed streams to generate per batch",
+    )
+    return parser.parse_args()
+
+
+def _sync_if_cuda(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+
+
+def _run_once(
+        extractor: GLiNER2,
+        *,
+        texts: Sequence[str],
+        structures: Dict[str, List[str]],
+        batch_size: int,
+        threshold: float,
+        device: torch.device,
+        packing_config: InferencePackingConfig | None,
+) -> tuple[List[dict], float]:
+    _sync_if_cuda(device)
+    start = time.perf_counter()
+    preds = extractor.batch_extract_json(
+        list(texts),
+        structures,
+        batch_size=batch_size,
+        threshold=threshold,
+        packing_config=packing_config,
+    )
+    _sync_if_cuda(device)
+    elapsed = time.perf_counter() - start
+    return preds, elapsed
+
+
+def main() -> None:
+    args = _parse_args()
+    device = torch.device(args.device)
+
+    texts: List[str] = list(DEFAULT_TEXTS)
+    structures: Dict[str, List[str]] = dict(DEFAULT_STRUCTURES)
+
+    extractor = GLiNER2.from_pretrained(args.model, map_location=str(device))
+    extractor.to(device)
+    extractor.eval()
+
+    max_length = args.max_length
+    if max_length is None:
+        max_length = getattr(extractor.encoder.config, "max_position_embeddings", None)
+    if max_length is None:
+        raise ValueError("Unable to infer max sequence length for packing; please pass --max-length")
+
+    sep_token_id = getattr(extractor.processor.tokenizer, "sep_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "eos_token_id", None)
+    if sep_token_id is None:
+        sep_token_id = getattr(extractor.processor.tokenizer, "pad_token_id", None)
+
+    packing_cfg = InferencePackingConfig(
+        max_length=int(max_length),
+        sep_token_id=sep_token_id,
+        streams_per_batch=args.streams_per_batch,
+    )
+
+    print("Running baseline (no packing)...")
+    baseline_preds, baseline_time = _run_once(
+        extractor,
+        texts=texts,
+        structures=structures,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=None,
+    )
+
+    print("Running with inference packing...")
+    packed_preds, packed_time = _run_once(
+        extractor,
+        texts=texts,
+        structures=structures,
+        batch_size=args.batch_size,
+        threshold=args.threshold,
+        device=device,
+        packing_config=packing_cfg,
+    )
+
+    identical = baseline_preds == packed_preds
+
+    print("Timing summary:")
+    print(f"  Without packing: {baseline_time:.3f} s")
+    print(f"  With packing   : {packed_time:.3f} s")
+    if packed_time > 0:
+        print(f"  Speedup        : {baseline_time / packed_time:.2f}x")
+    print(f"Predictions identical: {identical}")
+
+    if not identical:
+        print("Baseline predictions:", baseline_preds)
+        print("Packed predictions   :", packed_preds)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_infer_packing.py
+++ b/tests/test_infer_packing.py
@@ -1,0 +1,55 @@
+import torch
+
+from gliner2.infer_packing import InferencePackingConfig, pack_requests, unpack_spans
+
+
+class DummyEncoder(torch.nn.Module):
+    def __init__(self, vocab_size: int = 128, hidden_size: int = 16):
+        super().__init__()
+        self.embedding = torch.nn.Embedding(vocab_size, hidden_size)
+
+    def forward(self, input_ids, attention_mask=None):
+        # Mask is unused; we only need deterministic embeddings.
+        return self.embedding(input_ids)
+
+
+def _run_baseline(encoder, requests, pad_token_id: int):
+    lengths = [len(req["input_ids"]) for req in requests]
+    max_len = max(lengths)
+    input_ids = torch.full((len(requests), max_len), pad_token_id, dtype=torch.long)
+    for i, req in enumerate(requests):
+        tokens = torch.tensor(req["input_ids"], dtype=torch.long)
+        input_ids[i, : len(tokens)] = tokens
+    outputs = encoder(input_ids=input_ids)
+    result = []
+    for i, length in enumerate(lengths):
+        result.append(outputs[i, :length].detach())
+    return result
+
+
+def _run_packed(encoder, requests, cfg: InferencePackingConfig, pad_token_id: int):
+    packed = pack_requests(requests, cfg, pad_token_id)
+    outputs = encoder(
+        input_ids=packed.input_ids,
+        attention_mask=packed.pair_attention_mask,
+    )
+    unpacked = unpack_spans(outputs, packed)
+    return [tensor.detach() for tensor in unpacked]
+
+
+def test_pack_and_unpack_matches_baseline():
+    requests = [
+        {"input_ids": [1, 2, 3, 4, 5]},
+        {"input_ids": [6, 7, 8]},
+        {"input_ids": [9, 10, 11, 12]},
+    ]
+    pad_token_id = 0
+    cfg = InferencePackingConfig(max_length=16, sep_token_id=None, streams_per_batch=1)
+
+    encoder = DummyEncoder()
+    baseline = _run_baseline(encoder, requests, pad_token_id)
+    packed = _run_packed(encoder, requests, cfg, pad_token_id)
+
+    assert len(baseline) == len(packed)
+    for base, pack in zip(baseline, packed):
+        torch.testing.assert_close(base, pack, atol=1e-5, rtol=1e-4)


### PR DESCRIPTION
Add modular packing utilities and benchmarks for all tasks

- extract packing/mask handling into gliner2/packing_utils and wire model, processor, and inference to use it
- add packing-aware benchmarks for NER, classification, and structured extraction
- keep position ids consistent across packed runs and verify parity (tests/test_infer_packing, bench scripts) with cached DeBERTa model; observed ~6.3x NER speedup (8.94s -> 1.42s) with identical outputs
