### PR TITLE
feat: add max_len parameter to truncate long inputs at token level

### DIFF
--- a/gliner2/inference/engine.py
+++ b/gliner2/inference/engine.py
@@ -330,7 +330,8 @@ class GLiNER2(Extractor):
         num_workers: int = 0,
         format_results: bool = True,
         include_confidence: bool = False,
-        include_spans: bool = False
+        include_spans: bool = False,
+        max_len: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Extract from multiple texts with parallel preprocessing.
@@ -344,6 +345,11 @@ class GLiNER2(Extractor):
             format_results: Format output nicely
             include_confidence: Include confidence scores
             include_spans: Include character-level start/end positions
+            max_len: Maximum number of word tokens to process per text.
+                Tokens beyond this limit are silently dropped before the model
+                sees the input, so only entities within the first ``max_len``
+                tokens are returned.  Use this to cap memory usage on very long
+                documents.  ``None`` (default) means no truncation.
 
         Returns:
             List of extraction results
@@ -411,7 +417,7 @@ class GLiNER2(Extractor):
         dataset = list(zip(normalized, schema_dicts))
 
         from gliner2.training.trainer import ExtractorCollator
-        collator = ExtractorCollator(self.processor, is_training=False)
+        collator = ExtractorCollator(self.processor, is_training=False, max_len=max_len)
 
         loader = DataLoader(
             dataset,
@@ -1145,27 +1151,28 @@ class GLiNER2(Extractor):
 
     def extract(self, text: str, schema, threshold: float = 0.5,
                 format_results: bool = True, include_confidence: bool = False,
-                include_spans: bool = False) -> Dict:
+                include_spans: bool = False, max_len: Optional[int] = None) -> Dict:
         """Extract from single text."""
-        return self.batch_extract([text], schema, 1, threshold, 0, format_results, include_confidence, include_spans)[0]
+        return self.batch_extract([text], schema, 1, threshold, 0, format_results, include_confidence, include_spans, max_len=max_len)[0]
 
     def extract_entities(self, text: str, entity_types, threshold: float = 0.5,
                         format_results: bool = True, include_confidence: bool = False,
-                        include_spans: bool = False) -> Dict:
+                        include_spans: bool = False, max_len: Optional[int] = None) -> Dict:
         """Extract entities from text."""
         schema = self.create_schema().entities(entity_types)
-        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans)
+        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans, max_len=max_len)
 
     def batch_extract_entities(self, texts: List[str], entity_types, batch_size: int = 8,
                                threshold: float = 0.5, format_results: bool = True,
-                               include_confidence: bool = False, include_spans: bool = False) -> List[Dict]:
+                               include_confidence: bool = False, include_spans: bool = False,
+                               max_len: Optional[int] = None) -> List[Dict]:
         """Batch extract entities."""
         schema = self.create_schema().entities(entity_types)
-        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans)
+        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans, max_len=max_len)
 
     def classify_text(self, text: str, tasks: Dict, threshold: float = 0.5,
                      format_results: bool = True, include_confidence: bool = False,
-                     include_spans: bool = False) -> Dict:
+                     include_spans: bool = False, max_len: Optional[int] = None) -> Dict:
         """Classify text."""
         schema = self.create_schema()
         for name, config in tasks.items():
@@ -1175,11 +1182,12 @@ class GLiNER2(Extractor):
                 schema.classification(name, labels, **cfg)
             else:
                 schema.classification(name, config)
-        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans)
+        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans, max_len=max_len)
 
     def batch_classify_text(self, texts: List[str], tasks: Dict, batch_size: int = 8,
                            threshold: float = 0.5, format_results: bool = True,
-                           include_confidence: bool = False, include_spans: bool = False) -> List[Dict]:
+                           include_confidence: bool = False, include_spans: bool = False,
+                           max_len: Optional[int] = None) -> List[Dict]:
         """Batch classify texts."""
         schema = self.create_schema()
         for name, config in tasks.items():
@@ -1189,11 +1197,11 @@ class GLiNER2(Extractor):
                 schema.classification(name, labels, **cfg)
             else:
                 schema.classification(name, config)
-        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans)
+        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans, max_len=max_len)
 
     def extract_json(self, text: str, structures: Dict, threshold: float = 0.5,
                     format_results: bool = True, include_confidence: bool = False,
-                    include_spans: bool = False) -> Dict:
+                    include_spans: bool = False, max_len: Optional[int] = None) -> Dict:
         """Extract structured data."""
         schema = self.create_schema()
         for parent, fields in structures.items():
@@ -1201,11 +1209,12 @@ class GLiNER2(Extractor):
             for spec in fields:
                 name, dtype, choices, desc = self._parse_field_spec(spec)
                 builder.field(name, dtype=dtype, choices=choices, description=desc)
-        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans)
+        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans, max_len=max_len)
 
     def batch_extract_json(self, texts: List[str], structures: Dict, batch_size: int = 8,
                           threshold: float = 0.5, format_results: bool = True,
-                          include_confidence: bool = False, include_spans: bool = False) -> List[Dict]:
+                          include_confidence: bool = False, include_spans: bool = False,
+                          max_len: Optional[int] = None) -> List[Dict]:
         """Batch extract structured data."""
         schema = self.create_schema()
         for parent, fields in structures.items():
@@ -1213,21 +1222,22 @@ class GLiNER2(Extractor):
             for spec in fields:
                 name, dtype, choices, desc = self._parse_field_spec(spec)
                 builder.field(name, dtype=dtype, choices=choices, description=desc)
-        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans)
+        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans, max_len=max_len)
 
     def extract_relations(self, text: str, relation_types, threshold: float = 0.5,
                          format_results: bool = True, include_confidence: bool = False,
-                         include_spans: bool = False) -> Dict:
+                         include_spans: bool = False, max_len: Optional[int] = None) -> Dict:
         """Extract relations."""
         schema = self.create_schema().relations(relation_types)
-        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans)
+        return self.extract(text, schema, threshold, format_results, include_confidence, include_spans, max_len=max_len)
 
     def batch_extract_relations(self, texts: List[str], relation_types, batch_size: int = 8,
                                threshold: float = 0.5, format_results: bool = True,
-                               include_confidence: bool = False, include_spans: bool = False) -> List[Dict]:
+                               include_confidence: bool = False, include_spans: bool = False,
+                               max_len: Optional[int] = None) -> List[Dict]:
         """Batch extract relations."""
         schema = self.create_schema().relations(relation_types)
-        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans)
+        return self.batch_extract(texts, schema, batch_size, threshold, 0, format_results, include_confidence, include_spans, max_len=max_len)
 
     def _parse_field_spec(self, spec: Union[str, Dict]) -> Tuple[str, str, Optional[List[str]], Optional[str]]:
         """Parse field specification string or dictionary.

--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -35,6 +35,7 @@ class ExtractorConfig(PretrainedConfig):
             max_width: int = 8,
             counting_layer: str = "count_lstm",
             token_pooling: str = "first",
+            max_len: int = None,
             **kwargs
     ):
         super().__init__(**kwargs)
@@ -42,6 +43,7 @@ class ExtractorConfig(PretrainedConfig):
         self.max_width = max_width
         self.counting_layer = counting_layer
         self.token_pooling = token_pooling
+        self.max_len = max_len
 
 
 class Extractor(PreTrainedModel):

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -9,7 +9,7 @@ import copy
 import random
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Tuple, Iterator, List
+from typing import Any, Dict, Tuple, Iterator, List, Optional
 import torch
 from transformers import AutoTokenizer
 
@@ -220,7 +220,8 @@ class SchemaTransformer:
 
     def collate_fn_train(
             self,
-            batch: List[Tuple[str, Dict]]
+            batch: List[Tuple[str, Dict]],
+            max_len: Optional[int] = None,
     ) -> PreprocessedBatch:
         """
         Collate function for training DataLoader.
@@ -236,28 +237,35 @@ class SchemaTransformer:
 
         Args:
             batch: List of (text, schema) tuples from dataset
+            max_len: Maximum number of word tokens per text.  Tokens beyond
+                this limit are dropped before encoding.  ``None`` means no
+                truncation.
 
         Returns:
             PreprocessedBatch ready for model.forward()
         """
         self.is_training = True
-        return self._collate_batch(batch)
+        return self._collate_batch(batch, max_len=max_len)
 
     def collate_fn_inference(
             self,
-            batch: List[Tuple[str, Any]]
+            batch: List[Tuple[str, Any]],
+            max_len: Optional[int] = None,
     ) -> PreprocessedBatch:
         """
         Collate function for inference DataLoader.
 
         Args:
             batch: List of (text, schema) tuples
+            max_len: Maximum number of word tokens per text.  Tokens beyond
+                this limit are dropped before encoding.  ``None`` means no
+                truncation.
 
         Returns:
             PreprocessedBatch for batch_extract
         """
         self.is_training = False
-        return self._collate_batch(batch)
+        return self._collate_batch(batch, max_len=max_len)
 
     def transform_and_format(
             self,
@@ -286,7 +294,8 @@ class SchemaTransformer:
 
     def _collate_batch(
             self,
-            batch: List[Tuple[str, Any]]
+            batch: List[Tuple[str, Any]],
+            max_len: Optional[int] = None,
     ) -> PreprocessedBatch:
         """Internal collate implementation."""
         transformed_records = []
@@ -307,7 +316,7 @@ class SchemaTransformer:
             record = {"text": text, "schema": copy.deepcopy(schema)}
 
             try:
-                transformed = self._transform_record(record)
+                transformed = self._transform_record(record, max_len=max_len)
                 transformed_records.append(transformed)
             except Exception as e:
                 # Create minimal fallback record
@@ -315,8 +324,16 @@ class SchemaTransformer:
 
         return self._pad_batch(transformed_records)
 
-    def _transform_record(self, record: Dict[str, Any]) -> TransformedRecord:
-        """Transform a single record (internal)."""
+    def _transform_record(self, record: Dict[str, Any], max_len: Optional[int] = None) -> TransformedRecord:
+        """Transform a single record (internal).
+
+        Args:
+            record: Dict with ``text`` and ``schema`` keys.
+            max_len: Maximum number of word tokens to keep.  Truncation happens
+                after word-splitting but before schema encoding, so span
+                character positions in the output always point into the
+                original text string.  ``None`` means no truncation.
+        """
         record_ = copy.deepcopy(record)
         text, schema = record_["text"], record_["schema"]
 
@@ -339,6 +356,11 @@ class SchemaTransformer:
             text_tokens.append(tkn)
             start_idx_map.append(start)
             end_idx_map.append(end)
+
+        if max_len is not None:
+            text_tokens = text_tokens[:max_len]
+            start_idx_map = start_idx_map[:max_len]
+            end_idx_map = end_idx_map[:max_len]
 
         if prefix:
             text_tokens = prefix + text_tokens

--- a/gliner2/training/trainer.py
+++ b/gliner2/training/trainer.py
@@ -218,6 +218,7 @@ class TrainingConfig:
     max_train_samples: int = -1
     max_eval_samples: int = -1
     validate_data: bool = True
+    max_len: Optional[int] = None
 
     # LoRA Configuration (Parameter-Efficient Fine-Tuning)
     use_lora: bool = False
@@ -375,24 +376,25 @@ class ExtractorDataset(Dataset):
 class ExtractorCollator:
     """Data collator that converts raw records to model inputs."""
 
-    def __init__(self, processor: SchemaTransformer, is_training: bool = True):
+    def __init__(self, processor: SchemaTransformer, is_training: bool = True, max_len=None):
         self.processor = processor
         self.is_training = is_training
+        self.max_len = max_len
 
     def __call__(self, batch: List[Tuple[str, Dict]]):
         """
         Convert batch of (text, schema) tuples to PreprocessedBatch.
-        
+
         Args:
             batch: List of (text, schema) tuples from dataset
-            
+
         Returns:
             PreprocessedBatch ready for model.forward()
         """
         if self.is_training:
-            return self.processor.collate_fn_train(batch)
+            return self.processor.collate_fn_train(batch, max_len=self.max_len)
         else:
-            return self.processor.collate_fn_inference(batch)
+            return self.processor.collate_fn_inference(batch, max_len=self.max_len)
 
 
 # =============================================================================
@@ -798,7 +800,9 @@ class GLiNER2Trainer:
             sampler = DistributedSampler(dataset, shuffle=shuffle)
             shuffle = False
 
-        collator = ExtractorCollator(self.processor, is_training=is_training)
+        max_len = self.config.max_len or getattr(self.model.config, "max_len", None)
+        collator = ExtractorCollator(self.processor, is_training=is_training,
+                                     max_len=max_len)
         
         # Fix Bug #1 & #9: Handle small datasets
         # If dataset is smaller than batch_size, adjust to prevent empty dataloader

--- a/tests/test_inference_max_len.py
+++ b/tests/test_inference_max_len.py
@@ -1,0 +1,136 @@
+"""
+Test: max_len parameter in batch_extract / extract_entities.
+
+Shows how max_len truncates long inputs, how it affects span coverage
+and wall-clock time.
+
+Run:
+    python tests/test_max_len.py
+"""
+
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+from gliner2 import GLiNER2
+from gliner2.inference.engine import Schema
+
+
+MODEL_ID   = "fastino/gliner2-base-v1"
+SHORT_TEXT = "Apple CEO Tim Cook announced the iPhone 15 launch in Cupertino on September 12."
+LONG_TEXT  = SHORT_TEXT * 50   # ~700 tokens, ~4 100 chars
+ENTITY_TYPES = ["company", "person", "product", "location"]
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _flatten(raw) -> list:
+    """entities dict → flat list of span dicts, with 'label' injected from the key."""
+    if isinstance(raw, dict):
+        result = []
+        for label, spans in raw.items():
+            for e in (spans if isinstance(spans, list) else [spans]):
+                if isinstance(e, dict):
+                    result.append({**e, "label": label})
+        return result
+    return raw or []
+
+
+@dataclass
+class Result:
+    label:       str
+    input_chars: int
+    max_len:     Optional[int]
+    entities:    list
+    elapsed:     float
+
+    @property
+    def n(self): return len(self.entities)
+
+    @property
+    def max_end(self):
+        ends = [e["end"] for e in self.entities if isinstance(e, dict) and "end" in e]
+        return max(ends) if ends else 0
+
+
+def measure(label, model, schema, texts, **kw) -> Result:
+    t0 = time.perf_counter()
+    out = model.batch_extract(texts, schema, batch_size=len(texts),
+                              include_spans=True, **kw)
+    return Result(label, len(texts[0]), kw.get("max_len"),
+                  _flatten(out[0].get("entities", {})),
+                  time.perf_counter() - t0)
+
+
+# ── formatting ────────────────────────────────────────────────────────────────
+
+LINE_WIDTH = 64  # output box width in characters
+
+def header(title):
+    print(f"\n┌{'─' * (LINE_WIDTH - 2)}┐")
+    print(f"│  {title:<{LINE_WIDTH - 4}}│")
+    print(f"└{'─' * (LINE_WIDTH - 2)}┘")
+
+def row(key, value):
+    print(f"  {key:<16}{value}")
+
+def divider():
+    print(f"  {'─' * (LINE_WIDTH - 4)}")
+
+def print_result(r: Result, baseline: Optional[Result] = None):
+    header(r.label)
+    row("input chars",  r.input_chars)
+    row("max_len",      f"{r.max_len} tokens" if r.max_len else "none")
+    row("max span end", r.max_end)
+    row("time",         f"{r.elapsed:.3f}s")
+    if baseline and baseline.max_end:
+        pct    = r.max_end / baseline.max_end * 100
+        d_time = r.elapsed - baseline.elapsed
+        divider()
+        row("vs baseline",
+            f"covered {pct:.0f}% of text  /  time {d_time:+.3f}s")
+    if r.entities:
+        divider()
+        for e in r.entities[:3]:
+            if isinstance(e, dict):
+                print(f"  [{e.get('start'):4d}:{e.get('end'):4d}]"
+                      f"  {e.get('text')!r:22s}  ({e.get('label')})")
+        if r.n > 3:
+            print(f"  … {r.n - 3} more spans")
+
+
+# ── demo ─────────────────────────────────────────────────────────────────────
+
+def main():
+    print(f"Loading {MODEL_ID} …")
+    model  = GLiNER2.from_pretrained(MODEL_ID)
+    schema = Schema().entities(ENTITY_TYPES)
+    print("Done.\n")
+
+    r_short = measure("short text  |  max_len=384", model, schema, [SHORT_TEXT], max_len=384)
+    r_base  = measure("long text   |  no max_len  (baseline)", model, schema, [LONG_TEXT])
+    r_384   = measure("long text   |  max_len=384", model, schema, [LONG_TEXT], max_len=384)
+    r_50    = measure("long text   |  max_len=50",  model, schema, [LONG_TEXT], max_len=50)
+
+    print_result(r_short)
+    print_result(r_base)
+    print_result(r_384, baseline=r_base)
+    print_result(r_50,  baseline=r_base)
+
+    # mixed batch
+    texts = [SHORT_TEXT, LONG_TEXT, SHORT_TEXT]
+    t0  = time.perf_counter()
+    out = model.batch_extract(texts, schema, batch_size=4,
+                              include_spans=True, max_len=384)
+    elapsed = time.perf_counter() - t0
+    header("mixed batch (short + long + short)  |  max_len=384")
+    for i, r in enumerate(out):
+        n = len(_flatten(r.get("entities", {})))
+        row(f"text[{i}]", f"chars={len(texts[i]):5d}   entities={n}")
+    row("time", f"{elapsed:.3f}s")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_train_max_len.py
+++ b/tests/test_train_max_len.py
@@ -1,0 +1,72 @@
+"""
+Test: max_len in the training collator (ExtractorCollator).
+
+Shows that max_len truncates input_ids during both training and eval
+batch preparation. Uses a freshly initialised Extractor (no pretrained
+weights needed — we only test the collator, not the model forward pass).
+
+Run:
+    python tests/test_train_max_len.py
+"""
+
+from gliner2.model import Extractor, ExtractorConfig
+from gliner2.training.trainer import ExtractorCollator, ExtractorDataset
+from gliner2.training.data import InputExample
+
+
+SHORT_TEXT = "Apple CEO Tim Cook announced the iPhone 15 launch in Cupertino on September 12."
+LONG_TEXT  = SHORT_TEXT * 50   # ~700 tokens
+
+LINE_WIDTH = 64  # output box width in characters
+
+
+def header(title):
+    print(f"\n┌{'─' * (LINE_WIDTH - 2)}┐")
+    print(f"│  {title:<{LINE_WIDTH - 4}}│")
+    print(f"└{'─' * (LINE_WIDTH - 2)}┘")
+
+def row(key, value):
+    print(f"  {key:<16}{value}")
+
+
+def main():
+    examples = [
+        InputExample(
+            text=LONG_TEXT,
+            entities={"company": ["Apple"], "person": ["Tim Cook"]},
+        )
+    ]
+    dataset   = ExtractorDataset(examples, validate=False)
+    batch_raw = [dataset[0]]
+
+    for max_len in (None, 384):
+        config = ExtractorConfig(
+            model_name="bert-base-uncased",
+            max_width=8,
+            counting_layer="count_lstm",
+            token_pooling="first",
+            max_len=max_len,
+        )
+        print(f"Initialising Extractor (max_len={max_len}) …")
+        model = Extractor(config)
+
+        for is_training in (True, False):
+            collator = ExtractorCollator(model.processor,
+                                         is_training=is_training,
+                                         max_len=model.config.max_len)
+            batch   = collator(batch_raw)
+            seq_len = batch.input_ids.shape[1]
+
+            label = (
+                f"{'train' if is_training else 'eval '}"
+                f"  |  max_len={'none' if max_len is None else max_len}"
+            )
+            header(label)
+            row("input_ids len", f"{seq_len} tokens")
+            row("text tokens",   f"{len(batch.text_tokens[0])} tokens")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## PR Summary
This PR adds `max_len` support across the entire pipeline — from model config to training and inference. It allows truncating input sequences at the word-token level, which is useful for reducing OOM errors and improving inference speed on long texts. Default option is still `None`
### Edited
* Added `max_len: Optional[int]` to `ExtractorConfig` — model-level setting, saved with the model
* Added `max_len: Optional[int]` to `TrainingConfig` — training-time override (falls back to `model.config.max_len`)
* Propagated `max_len` through `ExtractorCollator` to both `collate_fn_train` and `collate_fn_inference` — previously it was silently ignored during training
* Added `max_len` to all convenience inference methods: `extract`, `extract_entities`, `batch_extract_entities`, `extract_json`, `batch_extract_json`, `extract_relations`, `batch_extract_relations`
* Added docstrings for `max_len` in `batch_extract`, `collate_fn_train`, `collate_fn_inference`, `_transform_record`

How it works: truncation happens at word-token level before schema encoding; character span positions in the output always reference the original text string.

### Test scripts

* `tests/test_inference_max_len.py` — inference: shows span coverage and time vs baseline across different `max_len` values
* `tests/test_train_max_len.py` — training: shows `input_ids` sequence length with and without `max_len` using a freshly initialised `Extractor`

### Examples of test scripts outputs
Output sample of `test_inference_max_len.py`:
```
┌──────────────────────────────────────────────────────────────┐
│  long text   |  no max_len  (baseline)                       │
└──────────────────────────────────────────────────────────────┘
  input chars     3950
  max_len         none
  max span end    1822
  time            0.295s
  ────────────────────────────────────────────────────────────
  [1817:1822]  'Apple'                 (company)
  [  89:  97]  'Tim Cook'              (person)
  [  33:  42]  'iPhone 15'             (product)
  … 1 more spans

┌──────────────────────────────────────────────────────────────┐
│  long text   |  max_len=384                                  │
└──────────────────────────────────────────────────────────────┘
  input chars     3950
  max_len         384 tokens
  max span end    84
  time            0.130s
  ────────────────────────────────────────────────────────────
  vs baseline     covered 5% of text  /  time -0.165s
  ────────────────────────────────────────────────────────────
  [  79:  84]  'Apple'                 (company)
  [  10:  18]  'Tim Cook'              (person)
  [  33:  42]  'iPhone 15'             (product)
  … 1 more spans
```


Output sample of `test_train_max_len.py`:

**Before**
```
┌──────────────────────────────────────────────────────────────┐
│  train  |  max_len=none                                      │
└──────────────────────────────────────────────────────────────┘
  input_ids len   863 tokens
  text tokens     750 tokens
```
**After `max_len`**
```
┌──────────────────────────────────────────────────────────────┐
│  train  |  max_len=384                                       │
└──────────────────────────────────────────────────────────────┘
  input_ids len   445 tokens
  text tokens     384 tokens
```