### PR TITLE
Fix: Make requests and urllib3 optional dependencies for API client

### DIFF
--- a/gliner2/__init__.py
+++ b/gliner2/__init__.py
@@ -2,13 +2,6 @@ __version__ = "1.2.4"
 
 from .inference.engine import GLiNER2, RegexValidator
 from .model import Extractor, ExtractorConfig
-from .api_client import (
-    GLiNER2API,
-    GLiNER2APIError,
-    AuthenticationError,
-    ValidationError,
-    ServerError,
-)
 from .training.lora import (
     LoRAConfig,
     LoRAAdapterConfig,
@@ -21,3 +14,46 @@ from .training.lora import (
     merge_lora_weights,
     unmerge_lora_weights,
 )
+
+# API client requires optional dependencies
+try:
+    from .api_client import (
+        GLiNER2API,
+        GLiNER2APIError,
+        AuthenticationError,
+        ValidationError,
+        ServerError,
+    )
+    _api_available = True
+except ImportError:
+    _api_available = False
+
+    # Define stubs for type hints and documentation
+    class GLiNER2APIError(Exception):
+        """Base exception for GLiNER2 API errors."""
+        pass
+
+    class AuthenticationError(GLiNER2APIError):
+        """Raised when API key is invalid or expired."""
+        pass
+
+    class ValidationError(GLiNER2APIError):
+        """Raised when request data is invalid."""
+        pass
+
+    class ServerError(GLiNER2APIError):
+        """Raised when server encounters an error."""
+        pass
+
+    class GLiNER2API:
+        """
+        API-based GLiNER2 client that mirrors the local model interface.
+
+        Note: This class requires the optional 'api' dependencies.
+        Install with: pip install gliner2[api]
+        """
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "API client requires optional dependencies. "
+                "Install with: pip install gliner2[api]"
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,4 +22,10 @@ dependencies = [
     "pydantic>=2.0.0",
 ]
 
+[project.optional-dependencies]
+api = [
+    "requests>=2.25.0",
+    "urllib3>=1.26.0",
+]
+
 dynamic = ["version"]


### PR DESCRIPTION
This fixes issue #60 where the package fails to import in environments where `requests`/`urllib3` are not installed.

## Problem
The `api_client.py` module imports `requests` and `urllib3`, but these were not declared in `pyproject.toml`. This caused import failures for users who only needed local inference.

## Solution
- Add `requests` and `urllib3` as optional dependencies under `[api]` extra
- Make `api_client` imports lazy with try-except in `__init__.py`
- Provide helpful error message when API client is used without dependencies

## Usage
**For local inference only (no extra dependencies):**
```bash
pip install gliner2
```

**For API functionality:**
```bash
pip install gliner2[api]
```

Closes #60