### PR TITLE
Handle non-JSON API responses with typed client errors

### DIFF
--- a/gliner2/api_client.py
+++ b/gliner2/api_client.py
@@ -344,6 +344,23 @@ class GLiNER2API:
         self.session.mount("http://", adapter)
         
         logger.debug(f"Initialized GLiNER2API for {self.base_url}")
+
+    @staticmethod
+    def _safe_json(response: requests.Response) -> Optional[Dict[str, Any]]:
+        """Parse response JSON safely, returning None for empty/invalid payloads."""
+        if not response.content:
+            return None
+
+        try:
+            data = response.json()
+        except ValueError:
+            logger.debug(
+                "Response body was not valid JSON (status=%s)",
+                response.status_code,
+            )
+            return None
+
+        return data if isinstance(data, dict) else None
     
     def _make_request(
         self,
@@ -400,15 +417,19 @@ class GLiNER2API:
             
             # Handle different error codes
             if response.status_code == 401:
-                error_data = response.json() if response.content else None
+                error_data = self._safe_json(response)
                 error_msg = (
                     error_data.get("detail", "Invalid or expired API key")
                     if error_data else "Invalid or expired API key"
                 )
-                raise AuthenticationError(error_msg, response_data=error_data)
+                raise AuthenticationError(
+                    error_msg,
+                    status_code=response.status_code,
+                    response_data=error_data,
+                )
             
             elif response.status_code in (400, 422):
-                error_data = response.json() if response.content else None
+                error_data = self._safe_json(response)
                 error_msg = (
                     error_data.get("detail", "Request validation failed")
                     if error_data else "Request validation failed"
@@ -420,7 +441,7 @@ class GLiNER2API:
                 )
             
             elif response.status_code >= 500:
-                error_data = response.json() if response.content else None
+                error_data = self._safe_json(response)
                 error_msg = (
                     error_data.get("detail", "Server error occurred")
                     if error_data else "Server error occurred"
@@ -432,7 +453,7 @@ class GLiNER2API:
                 )
             
             elif not response.ok:
-                error_data = response.json() if response.content else None
+                error_data = self._safe_json(response)
                 error_msg = (
                     error_data.get("detail", f"Request failed with status {response.status_code}")
                     if error_data else f"Request failed with status {response.status_code}"
@@ -442,8 +463,21 @@ class GLiNER2API:
                     status_code=response.status_code,
                     response_data=error_data,
                 )
-            
-            data = response.json()
+
+            if not response.content:
+                raise GLiNER2APIError(
+                    "Empty response body from API",
+                    status_code=response.status_code,
+                )
+
+            try:
+                data = response.json()
+            except ValueError as e:
+                raise GLiNER2APIError(
+                    "Invalid JSON response from API",
+                    status_code=response.status_code,
+                ) from e
+
             return data.get("result", data)
         
         except requests.exceptions.Timeout:

--- a/tests/test_api_client_error_handling.py
+++ b/tests/test_api_client_error_handling.py
@@ -1,0 +1,79 @@
+import json
+
+import pytest
+
+from gliner2.api_client import (
+    AuthenticationError,
+    GLiNER2API,
+    GLiNER2APIError,
+    ServerError,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, content: bytes, json_data=None, json_error: Exception | None = None):
+        self.status_code = status_code
+        self.content = content
+        self._json_data = json_data
+        self._json_error = json_error
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 300
+
+    def json(self):
+        if self._json_error is not None:
+            raise self._json_error
+        return self._json_data
+
+
+@pytest.fixture
+def api_client() -> GLiNER2API:
+    return GLiNER2API(api_key="test-key")
+
+
+def test_401_non_json_body_raises_authentication_error(api_client: GLiNER2API):
+    response = _FakeResponse(
+        status_code=401,
+        content=b"<html>Unauthorized</html>",
+        json_error=json.JSONDecodeError("Expecting value", "", 0),
+    )
+    api_client.session.post = lambda *args, **kwargs: response
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        api_client.extract_entities("hello", ["person"])
+
+    assert str(exc_info.value) == "Invalid or expired API key"
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.response_data is None
+
+
+def test_500_non_json_body_raises_server_error(api_client: GLiNER2API):
+    response = _FakeResponse(
+        status_code=500,
+        content=b"<html>Server Error</html>",
+        json_error=json.JSONDecodeError("Expecting value", "", 0),
+    )
+    api_client.session.post = lambda *args, **kwargs: response
+
+    with pytest.raises(ServerError) as exc_info:
+        api_client.extract_entities("hello", ["person"])
+
+    assert str(exc_info.value) == "Server error occurred"
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.response_data is None
+
+
+def test_200_non_json_body_raises_api_error(api_client: GLiNER2API):
+    response = _FakeResponse(
+        status_code=200,
+        content=b"<html>OK but not JSON</html>",
+        json_error=json.JSONDecodeError("Expecting value", "", 0),
+    )
+    api_client.session.post = lambda *args, **kwargs: response
+
+    with pytest.raises(GLiNER2APIError) as exc_info:
+        api_client.extract_entities("hello", ["person"])
+
+    assert "Invalid JSON response from API" in str(exc_info.value)
+    assert exc_info.value.status_code == 200


### PR DESCRIPTION
## What changed
- Added `GLiNER2API._safe_json()` to parse error responses defensively when the API returns empty or non-JSON bodies.
- Updated `_make_request()` error paths (401/400/422/5xx/other non-2xx) to use safe JSON parsing instead of directly calling `response.json()`.
- Added explicit `status_code` to `AuthenticationError` for consistent error metadata.
- Added explicit success-path guards:
  - raise `GLiNER2APIError("Empty response body from API")` for empty 2xx payloads
  - raise `GLiNER2APIError("Invalid JSON response from API")` when a 2xx body is not valid JSON
- Added focused regression tests in `tests/test_api_client_error_handling.py` covering:
  - 401 + non-JSON body => `AuthenticationError`
  - 500 + non-JSON body => `ServerError`
  - 200 + non-JSON body => `GLiNER2APIError`

## Why
- The API client previously assumed any non-empty error body was JSON. If upstream returned HTML/plaintext (common behind proxies/CDNs/failure pages), `response.json()` raised a decode exception and bypassed the intended typed error handling.
- This made failures harder to handle programmatically and could leak low-level decode exceptions to users.

## Insight / Why this matters
- **Root cause:** error classification was coupled to JSON decoding; decode failures interrupted the control flow before `AuthenticationError` / `ValidationError` / `ServerError` could be raised.
- **Why easy to miss:** normal happy-path testing and most local mocks return JSON, so decode-failure paths are rarely exercised.
- **Tradeoff:** non-dict JSON error payloads are treated as absent metadata (`response_data=None`) to keep error typing stable and avoid brittle assumptions.
- **Impact:** callers now reliably receive typed, status-aware exceptions even when upstream responses are malformed or transformed by intermediaries.

## Practical gain / Why this matters
- Improves production reliability in real network conditions (proxy error pages, gateway misconfigurations, unexpected plaintext responses).
- Makes retry/alert logic safer by preserving semantic exception types and status codes.
- Reduces debugging time by replacing raw JSON decode crashes with actionable API-client errors.

## Testing
- ✅ `pytest -q tests/test_api_client_error_handling.py`
  - `3 passed`
- ✅ `scripts/clone_and_test.sh fastino-ai/GLiNER2`
  - `31 passed`

## Risk analysis
- Scope is limited to API response parsing and error wrapping in `gliner2/api_client.py` plus additive tests.
- No model/inference logic changes.
- Behavior is backward-compatible for valid JSON responses; changes only affect previously brittle malformed-response paths.
