### PR TITLE
Fix regex validator returning empty results

### DIFF
--- a/gliner2/inference/engine.py
+++ b/gliner2/inference/engine.py
@@ -1082,8 +1082,9 @@ class GLiNER2(Extractor):
                             instance[fname] = None
                 else:
                     # Regular span field - track positions
+                    span_threshold = 0.0 if validators else field_threshold
                     spans = self._find_spans(
-                        scores[fidx], field_threshold, text_len, text,
+                        scores[fidx], span_threshold, text_len, text,
                         start_map, end_map
                     )
 


### PR DESCRIPTION
Fixes #67

When a field has validators (e.g. `RegexValidator`), the model's raw scores are often
very low, so the default threshold was filtering everything out before the validator
could even run. Fix: skip the threshold when validators are present and let them do
the filtering instead.