### PR TITLE
fix cls threhsold not being used

### DIFF
--- a/gliner2/inference/engine.py
+++ b/gliner2/inference/engine.py
@@ -791,13 +791,11 @@ class GLiNER2(Extractor):
 
         if is_multi:
             chosen = [(labels[j], probs[j].item()) for j in range(len(labels)) if probs[j].item() >= cls_threshold]
-            if not chosen:
-                best = int(torch.argmax(probs).item())
-                chosen = [(labels[best], probs[best].item())]
             results[schema_name] = chosen
         else:
             best = int(torch.argmax(probs).item())
-            results[schema_name] = (labels[best], probs[best].item())
+            best_score = probs[best].item()
+            results[schema_name] = (labels[best], best_score) if best_score >= cls_threshold else None
 
     def _extract_span_result(
         self,


### PR DESCRIPTION
Fixes #66

`cls_threshold` was being read but never actually used in single-label classification. The top label was always returned regardless of its score. Also removed the multi-label fallback that had the same problem, where if nothing passed the threshold it would return the best label anyway. Both paths now return `None` or `[]` when nothing meets the threshold. Happy to adjust the return values if something different is preferred