### PR TITLE
fix duplicate entities at different positions being dedup

### DIFF
--- a/gliner2/inference/engine.py
+++ b/gliner2/inference/engine.py
@@ -1293,8 +1293,8 @@ class GLiNER2(Extractor):
                 for span in spans:
                     if isinstance(span, tuple):
                         text, conf, start, end = span
-                        if text and text.lower() not in seen:
-                            seen.add(text.lower())
+                        if text and (text.lower(), start, end) not in seen:
+                            seen.add((text.lower(), start, end))
                             unique.append({"text": text, "confidence": conf} if include_confidence else text)
                     elif isinstance(span, dict):
                         # Handle dict format (with confidence/spans)
@@ -1323,9 +1323,9 @@ class GLiNER2(Extractor):
                 seen = set()
                 for v in value:
                     if isinstance(v, tuple):
-                        text, conf, _, _ = v
-                        if text and text.lower() not in seen:
-                            seen.add(text.lower())
+                        text, conf, start, end = v
+                        if text and (text.lower(), start, end) not in seen:
+                            seen.add((text.lower(), start, end))
                             unique.append({"text": text, "confidence": conf} if include_confidence else text)
                     elif isinstance(v, dict):
                         # Handle dict format (with confidence/spans)

--- a/tests/test_entity_extraction.py
+++ b/tests/test_entity_extraction.py
@@ -103,6 +103,19 @@ def test_batch_entity_extraction():
     print("=" * 80)
 
 
+def test_duplicate_entities_at_different_positions():
+    """Same entity text at different positions should both be returned."""
+    # Simulate two spans: "John" at pos 11 and "John" at pos 35
+    entities = {
+        "name": [
+            ("John", 0.99, 11, 15),
+            ("John", 0.98, 35, 39),
+        ]
+    }
+    result = GLiNER2._format_entity_dict(None, entities, include_confidence=False)
+    assert len(result["name"]) == 2, "Both occurrences of 'John' should be returned"
+
+
 if __name__ == "__main__":
     test_entity_extraction()
     test_batch_entity_extraction()


### PR DESCRIPTION
Fixes #59

`format_results=True` was deduplicating entities by text value alone, so the same word appearing at two different positions (e.g. "John" at pos 11 and pos 35) was collapsed into one result. Fixed by keying on `(text, start, end)` instead of just `text`, so truly duplicate spans are still deduplicated but distinct occurrences are preserved. Also adds a unit test covering this case.