### PR TITLE
Add Flash Attention Support

### DIFF
--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -144,7 +144,7 @@ class Extractor(PreTrainedModel):
         self._print_config(config)
 
     def _print_config(self, config):
-        _attn_impl, _ = self._resolve_attn_impl()
+        _attn_impl, _dtype = self._resolve_attn_impl()
         _actual = getattr(self.encoder.config, "_attn_implementation", None)
         print("=" * 60)
         print("🧠 Model Configuration")
@@ -156,6 +156,7 @@ class Extractor(PreTrainedModel):
             print(f"Attention backend  : requested={_attn_impl!r}, actual={_actual!r} (fallback — model does not support {_attn_impl})")
         else:
             print(f"Attention backend  : {_actual!r}")
+        print(f"Encoder dtype      : {_dtype}")
         print("=" * 60)
 
     @staticmethod
@@ -171,7 +172,13 @@ class Extractor(PreTrainedModel):
         _flash = os.environ.get("FLASH_ATTN", "").lower() in ("1", "true", "yes")
         if _flash:
             _attn_impl = "flash_attention_2"
-            _dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+            _dtype_env = os.environ.get("FLASH_ATTN_DTYPE", "").lower()
+            if _dtype_env == "fp16":
+                _dtype = torch.float16
+            elif _dtype_env == "bf16":
+                _dtype = torch.bfloat16
+            else:
+                _dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
         else:
             _attn_impl = None
             _dtype = None
@@ -209,7 +216,7 @@ class Extractor(PreTrainedModel):
                 encoder_config,
                 trust_remote_code=True,
                 attn_implementation=_attn_impl,
-                **({"torch_dtype": _dtype} if _dtype is not None else {}),
+                **({"dtype": _dtype} if _dtype is not None else {}),
             )
 
         pretrained_config = AutoConfig.from_pretrained(model_name)
@@ -222,7 +229,7 @@ class Extractor(PreTrainedModel):
             model_name,
             trust_remote_code=True,
             attn_implementation=_attn_impl,
-            **({"torch_dtype": _dtype} if _dtype is not None else {}),
+            **({"dtype": _dtype} if _dtype is not None else {}),
         )
 
     # =========================================================================

--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -144,20 +144,43 @@ class Extractor(PreTrainedModel):
         self._print_config(config)
 
     def _print_config(self, config):
+        _attn_impl, _ = self._resolve_attn_impl()
+        _actual = getattr(self.encoder.config, "_attn_implementation", None)
         print("=" * 60)
         print("🧠 Model Configuration")
         print("=" * 60)
         print(f"Encoder model      : {config.model_name}")
         print(f"Counting layer     : {config.counting_layer}")
         print(f"Token pooling      : {config.token_pooling}")
+        print(f"Attention backend  : requested={_attn_impl!r}, actual={_actual!r}")
         print("=" * 60)
+
+    @staticmethod
+    def _resolve_attn_impl() -> tuple:
+        """Resolve attention implementation and dtype from environment.
+
+        FLASH_ATTN=1 (or "true"/"yes") enables flash_attention_2.
+        USE_FLASHDEBERTA=1 enables the FlashDeberta backend for DeBERTa-v2 models.
+
+        Returns:
+            (attn_impl, dtype) — both may be None when flash attention is off.
+        """
+        _flash = os.environ.get("FLASH_ATTN", "").lower() in ("1", "true", "yes")
+        if _flash:
+            _attn_impl = "flash_attention_2"
+            _dtype = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+        else:
+            _attn_impl = None
+            _dtype = None
+        return _attn_impl, _dtype
 
     @staticmethod
     def _load_encoder(model_name: str, encoder_config=None) -> nn.Module:
         """Load the transformer encoder, using optimized backends when available.
 
-        Checks for FlashDeberta support when the encoder is DebertaV2-based.
-        Activated by setting the USE_FLASHDEBERTA environment variable.
+        Checks for FlashDeberta support when the encoder is DebertaV2-based
+        (USE_FLASHDEBERTA env var), and for generic flash_attention_2 support
+        via the FLASH_ATTN env var.
 
         Args:
             model_name: Name or path of the pretrained model.
@@ -167,6 +190,8 @@ class Extractor(PreTrainedModel):
         Returns:
             The initialized encoder module.
         """
+        _attn_impl, _dtype = Extractor._resolve_attn_impl()
+
         use_flashdeberta = (
             IS_FLASHDEBERTA
             and os.environ.get("USE_FLASHDEBERTA", "")
@@ -184,7 +209,13 @@ class Extractor(PreTrainedModel):
         if config_name == "DebertaV2Config" and use_flashdeberta:
             print("Using FlashDeberta backend.")
             return FlashDebertaV2Model.from_pretrained(model_name)
-        return AutoModel.from_pretrained(model_name, trust_remote_code=True)
+
+        return AutoModel.from_pretrained(
+            model_name,
+            trust_remote_code=True,
+            attn_implementation=_attn_impl,
+            **({"torch_dtype": _dtype} if _dtype is not None else {}),
+        )
 
     # =========================================================================
     # Main Forward Pass

--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -152,7 +152,10 @@ class Extractor(PreTrainedModel):
         print(f"Encoder model      : {config.model_name}")
         print(f"Counting layer     : {config.counting_layer}")
         print(f"Token pooling      : {config.token_pooling}")
-        print(f"Attention backend  : requested={_attn_impl!r}, actual={_actual!r}")
+        if _attn_impl is not None and _actual != _attn_impl:
+            print(f"Attention backend  : requested={_attn_impl!r}, actual={_actual!r} (fallback — model does not support {_attn_impl})")
+        else:
+            print(f"Attention backend  : {_actual!r}")
         print("=" * 60)
 
     @staticmethod
@@ -202,7 +205,12 @@ class Extractor(PreTrainedModel):
             if config_name == "DebertaV2Config" and use_flashdeberta:
                 print("Using FlashDeberta backend.")
                 return FlashDebertaV2Model(encoder_config)
-            return AutoModel.from_config(encoder_config, trust_remote_code=True)
+            return AutoModel.from_config(
+                encoder_config,
+                trust_remote_code=True,
+                attn_implementation=_attn_impl,
+                **({"torch_dtype": _dtype} if _dtype is not None else {}),
+            )
 
         pretrained_config = AutoConfig.from_pretrained(model_name)
         config_name = pretrained_config.__class__.__name__


### PR DESCRIPTION
# Add Flash Attention 2 support to GLiNER 2
 
## About
 
Adds Flash Attention 2 support to GLiNER 2.
 
Tested on ModernBERT backbone with [hivetrace/gliner-guard-uniencoder](https://huggingface.co/hivetrace/gliner-guard-uniencoder) on A100 SXM.
 
## TL;DR
 
FA2 gives a meaningful speedup only on long inputs (from ~20k chars / ~3k tokens (approx.)). On short sequences the difference is within noise, sometimes slightly slower than SDPA. Break-even point: ~5k chars, stable speedup from 20k onward.
 
## Deps & hardware
 
```bash
PyTorch    : 2.8.0+cu128
CUDA       : 12.8
GPU        : NVIDIA A100-SXM4-80GB
flash_attn : 2.8.3
```
 
## Installation
 
```bash
pip install -q "gliner2 @ git+https://github.com/bogdanminko/GLiNER2.git"
wget "https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl"
pip install "flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp311-cp311-linux_x86_64.whl"
```
 
Important: torch / python / CUDA versions must match the pre-built wheel.
Otherwise you could install it from source : https://github.com/dao-ailab/flash-attention
 
## Usage
 
FA2 is auto-detected on model load, or can be forced via an environment variable (same pattern as Flash DeBERTa).
You can also set the dtype via env var:
 
```bash
FLASH_ATTN=1
FLASH_ATTN_DTYPE=fp16 #you can use bf16
```
 
```python
from gliner2 import GLiNER2

model = GLiNER2.from_pretrained("hivetrace/gliner-guard-uniencoder")

PII_LABELS = ["person", "address", "email", "phone"]
SAFETY_LABELS = ["safe", "unsafe"]
schema = (model.create_schema()
    .entities(entity_types=PII_LABELS, threshold=0.4)
    .classification(task="safety", labels=SAFETY_LABELS)
)

result = model.extract(
    "Send $500 to John Smith at john.smith@gmail.com or I'll leak your photos",
    schema=schema
)
```
 
When FA2 is picked up, the load log will show:
 
```
🧠 Model Configuration
============================================================
Encoder model      : bogdanminko/mmBERT-small
Counting layer     : count_lstm_v2
Token pooling      : first
Attention backend  : 'flash_attention_2'
Encoder dtype      : torch.float16
============================================================
```
 
## Benchmark
### Pipeline
Benchmarking pipeline as a Colab notebook: https://colab.research.google.com/drive/1GLZP60Np3blvaY70YVxMlvCSpF_vQaxv?usp=sharing
 
Note: Colab's T4 does not support FA2, so benchmarks were run on A100.
 
### Results
```

── batch_size = 1 ──
     chars   ~tokens        SDPA         FA2    Speedup    ms/req SDPA    ms/req FA2
  --------  --------  ----------  ----------  ---------  -------------  ------------
       500        83       29.7ms       31.7ms      0.94x          29.7ms         31.7ms  SLOWER
      3000       500       39.8ms       41.7ms      0.95x          39.8ms         41.7ms  ~same
      5000       833       47.4ms       48.0ms      0.99x          47.4ms         48.0ms  ~same
     10000      1666       66.9ms       67.8ms      0.99x          66.9ms         67.8ms  ~same
     20000      3333      124.9ms      110.0ms      1.14x         124.9ms        110.0ms  faster
     40000      6666      265.1ms      205.4ms      1.29x         265.1ms        205.4ms  faster
     60000     10000      428.7ms      305.8ms      1.40x         428.7ms        305.8ms  faster

── batch_size = 4 ──
     chars   ~tokens        SDPA         FA2    Speedup    ms/req SDPA    ms/req FA2
  --------  --------  ----------  ----------  ---------  -------------  ------------
       500        83       60.2ms       64.9ms      0.93x          15.0ms         16.2ms  SLOWER
      3000       500       99.5ms      103.6ms      0.96x          24.9ms         25.9ms  ~same
      5000       833      136.7ms      133.2ms      1.03x          34.2ms         33.3ms  ~same
     10000      1666      237.4ms      228.7ms      1.04x          59.4ms         57.2ms  ~same
     20000      3333      463.9ms      433.7ms      1.07x         116.0ms        108.4ms  faster
     40000      6666     1099.2ms      803.2ms      1.37x         274.8ms        200.8ms  faster
     60000     10000     1789.1ms     1310.6ms      1.37x         447.3ms        327.7ms  faster

── batch_size = 8 ──
     chars   ~tokens        SDPA         FA2    Speedup    ms/req SDPA    ms/req FA2
  --------  --------  ----------  ----------  ---------  -------------  ------------
       500        83      100.7ms      104.5ms      0.96x          12.6ms         13.1ms  ~same
      3000       500      189.7ms      189.1ms      1.00x          23.7ms         23.6ms  ~same
      5000       833      272.3ms      255.9ms      1.06x          34.0ms         32.0ms  faster
     10000      1666      465.4ms      452.4ms      1.03x          58.2ms         56.5ms  ~same
     20000      3333      996.7ms      900.3ms      1.11x         124.6ms        112.5ms  faster
     40000      6666     2100.8ms     1699.9ms      1.24x         262.6ms        212.5ms  faster
     60000     10000     3483.5ms     2493.8ms      1.40x         435.4ms        311.7ms  faster

── batch_size = 32 ──
     chars   ~tokens        SDPA         FA2    Speedup    ms/req SDPA    ms/req FA2
  --------  --------  ----------  ----------  ---------  -------------  ------------
       500        83      348.5ms      350.2ms      1.00x          10.9ms         10.9ms  ~same
      3000       500      719.9ms      717.7ms      1.00x          22.5ms         22.4ms  ~same
      5000       833     1107.3ms     1096.2ms      1.01x          34.6ms         34.3ms  ~same
     10000      1666     1986.1ms     1905.8ms      1.04x          62.1ms         59.6ms  ~same
     20000      3333     3743.7ms     3418.8ms      1.10x         117.0ms        106.8ms  faster
     40000      6666     8072.8ms     6482.5ms      1.25x         252.3ms        202.6ms  faster
     60000     10000    13380.6ms     9643.7ms      1.39x         418.1ms        301.4ms  faster
```
 
## When to enable
 
| Scenario | Recommendation |
|---|---|
| Short texts (<5k chars) | stick with SDPA |
| Mixed lengths / long docs (20k+) | enable FA2, ~1.1x–1.4x speedup |