### PR TITLE
Add missing license and metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ version = {attr = "gliner2.__version__"}
 name = "gliner2"
 description = "GLiNER2: Unified Schema-Based Information Extraction and Text Classification"
 readme = "README.md"
-license = "Apache-2.0"
+license = {file = "LICENSE"}
 requires-python = ">=3.8"
 
 maintainers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,19 @@ version = {attr = "gliner2.__version__"}
 
 [project]
 name = "gliner2"
+description = "GLiNER2: Unified Schema-Based Information Extraction and Text Classification"
 readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.8"
 
 maintainers = [
     {name = "Urchade Zaratiana"},
+]
+
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
 ]
 
 dependencies = [
@@ -23,3 +31,7 @@ dependencies = [
 ]
 
 dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/fastino-ai/GLiNER2"
+Repository = "https://github.com/fastino-ai/GLiNER2"


### PR DESCRIPTION
## Summary

The `pyproject.toml` is missing license and other metadata fields. As a result, the published PyPI package shows no license information, making it difficult for downstream projects to verify compliance with Apache 2.0.

This PR adds:
- `license = "Apache-2.0"` (matching the existing LICENSE file)
- `description` field
- `classifiers` (license, Python, OS)
- `[project.urls]` (Homepage and Repository)

A new PyPI release after this merge will populate the missing metadata on https://pypi.org/project/gliner2/.