### PR TITLE
ENG-1268: propagate base_model_name_or_path through PEFT adapter saves

### DIFF
--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -732,6 +732,16 @@ class Extractor(PreTrainedModel):
 
         model.load_state_dict(state_dict)
 
+        # Mirror HF PreTrainedModel.from_pretrained semantics so downstream
+        # PEFT saves derive ``base_model_name_or_path`` correctly. PEFT reads
+        # ``self.base_model.model.__dict__.get("name_or_path")`` when serialising
+        # an adapter; without an explicit instance attribute that lookup misses
+        # the ``PreTrainedModel.name_or_path`` property and writes "" into
+        # ``adapter_config.json``, which breaks downstream resolvers (e.g.
+        # vLLM's ``lora_filesystem_resolver``) that match on this field.
+        model.config._name_or_path = repo_or_dir
+        model.name_or_path = repo_or_dir
+
         if map_location is not None:
             model = model.to(map_location)
 
@@ -829,10 +839,19 @@ class Extractor(PreTrainedModel):
         from peft import LoraConfig as PeftLoraConfig, get_peft_model
         from gliner2.training.lora import _resolve_targets, _cast_lora_dtype
 
+        # Pin ``base_model_name_or_path`` up front so adapters saved via
+        # ``PeftModel.save_pretrained`` always carry a concrete identifier
+        # (matches what the base model was loaded from in ``from_pretrained``).
+        base_id = (
+            getattr(self, "name_or_path", "")
+            or getattr(self.config, "_name_or_path", "")
+            or None
+        )
         cfg = PeftLoraConfig(
             r=r, lora_alpha=alpha, lora_dropout=dropout,
             target_modules=_resolve_targets(self, targets or ["encoder"]),
             bias="none", use_dora=use_dora,
+            base_model_name_or_path=base_id,
         )
         peft_model = get_peft_model(self, cfg)
         _cast_lora_dtype(peft_model)


### PR DESCRIPTION
## Summary

Follow-up to #106 (PEFT migration). Adapters saved via
``PeftModel.save_pretrained`` currently record an empty string in
``adapter_config.json::base_model_name_or_path``. Downstream LoRA
resolvers that match on this field (e.g. vLLM's built-in
``lora_filesystem_resolver``) compare it against the server's
``model_config.model`` via strict string equality and return ``None`` on
mismatch, which surfaces as a ``404 Not Found`` at inference time —
the adapter is effectively unreachable via filesystem-based dynamic
discovery.

## Root cause

``PeftModel.save_pretrained`` derives ``base_model_name_or_path`` via

    self.base_model.model.__dict__.get(\"name_or_path\", None)

That lookup inspects ``__dict__`` directly, so it bypasses
``PreTrainedModel.name_or_path`` (a class-level property that would
otherwise fall through to ``self.config.name_or_path``). Since
``Extractor.from_pretrained`` never set ``config._name_or_path`` nor
assigned an instance attribute, the lookup returns ``None`` and PEFT
serialises it as an empty string.

The stock HF ``PreTrainedModel.from_pretrained`` populates
``config._name_or_path`` as part of its load path; ``Extractor``'s
override doesn't, so the attribute was silently absent for every
``Extractor.from_pretrained(...).apply_lora(...)`` base.

## Change

Two small, independent hunks in ``gliner2/model.py``:

1. ``Extractor.from_pretrained`` — assign ``self.name_or_path`` and
   ``self.config._name_or_path`` to the supplied ``repo_or_dir`` before
   returning. Mirrors HF ``PreTrainedModel.from_pretrained`` semantics
   and makes PEFT's ``__dict__.get`` pick up the right value.
2. ``Extractor.apply_lora`` — pass
   ``base_model_name_or_path=<resolved id>`` into ``LoraConfig``
   explicitly so the value is pinned on the config at adapter-apply
   time and PEFT never has to fall back to ``__dict__`` inspection.

## Validation

Adapters retrained against the patched codepath now serialise with a
populated identifier, e.g.

    \"base_model_name_or_path\": \"fastino/gliner2-large-v1\"

which resolves correctly under vLLM's ``lora_filesystem_resolver``
(filesystem-discovery + ``VLLM_ALLOW_RUNTIME_LORA_UPDATING=True``).

## Test plan

- [x] Retrain 64-adapter grid via downstream harness — all
      ``adapter_config.json`` files carry
      ``\"base_model_name_or_path\": \"fastino/gliner2-large-v1\"`` and
      ``\"peft_type\": \"LORA\"`` (verified by inspecting the Modal
      volume after ``modal run train_adapters.py::train_all``).
- [x] vLLM serve with ``lora_filesystem_resolver`` + ``--max-loras 32``
      successfully enrols retrained adapters under concurrent
      cross-LoRA load — previously all requests 404'd.
- [ ] Manual: ``PeftModel.from_pretrained(extractor, \"/adapters/<name>\")``
      under the PEFT-native loader still works unchanged.

Made with [Cursor](https://cursor.com)