### PR TITLE
fix: add missing local extra to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,13 @@ dependencies = [
 
 dynamic = ["version"]
 
+[project.optional-dependencies]
+local = [
+    "torch",
+    "transformers",
+    "peft",
+]
+
 [project.urls]
 Homepage = "https://github.com/fastino-ai/GLiNER2"
 Repository = "https://github.com/fastino-ai/GLiNER2"


### PR DESCRIPTION
## Problem

The README and documentation instruct users to install with `pip install gliner2[local]`, but the `[project.optional-dependencies]` section is missing from `pyproject.toml`. This causes:

```
ERROR: gliner2 1.3.1 does not have an extra named 'local'
```

Fixes #111

## Fix

Add `[project.optional-dependencies]` with a `local` extra containing the packages needed for local inference and training:
- `torch` - PyTorch for model inference
- `transformers` - HuggingFace transformers for model loading
- `peft` - Parameter-efficient fine-tuning (used in `training/lora.py`)
