### PR TITLE
feat: Improve token splitting for CJK languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ Thumbs.db
 *.log
 
 test_api_client.py
+
+# uv
+uv.lock

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ pip install gliner2
 
 # Full local inference and training (installs torch, transformers, etc.)
 pip install gliner2[local]
+
+# Improve CJK languages token-splitting (installs jieba|sudachipy|kiwipiepy etc.)
+pip install gliner2[zh|ja|ja-small|ja-full|ko]
 ```
 
 The base install gives you `Schema`, `SchemaInput`, `RegexValidator`, `GLiNER2API`,
@@ -48,6 +51,38 @@ result = extractor.extract_entities(text, ["company", "person", "product", "loca
 
 print(result)
 # {'entities': {'company': ['Apple'], 'person': ['Tim Cook'], 'product': ['iPhone 15'], 'location': ['Cupertino']}}
+```
+
+### For Chinese text
+
+```python
+from gliner2 import GLiNER2  # requires gliner2[local,zh]
+
+extractor = GLiNER2.from_pretrained("fastino/gliner2-multi-v1", language="zh")
+```
+
+### For Japanese text
+
+Additional options:
+
+- `ja_dict_type`: Depending on the size of the vocabulary included, you can choose from [`small`, `core`, `full`].
+  - Default: `core`
+  - The available options correspond to the optional dependencies selected during the `pip install` command.
+- `ja_split_mode`: Depending on the token granularity, you can choose from [`A`, `B`, `C`].
+  - Default: `C`
+
+```python
+from gliner2 import GLiNER2  # requires gliner2[local,ja|ja-small|ja-full]
+
+extractor = GLiNER2.from_pretrained("fastino/gliner2-multi-v1", language="ja", ja_dict_type="small|core|full", ja_split_mode="A|B|C")
+```
+
+### For Korean text
+
+```python
+from gliner2 import GLiNER2  # requires gliner2[local,ko]
+
+extractor = GLiNER2.from_pretrained("fastino/gliner2-multi-v1", language="ko")
 ```
 
 ### Quantization and Compilation

--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -74,7 +74,7 @@ class Extractor(PreTrainedModel):
     """
     config_class = ExtractorConfig
 
-    def __init__(self, config: ExtractorConfig, encoder_config=None, tokenizer=None):
+    def __init__(self, config: ExtractorConfig, encoder_config=None, tokenizer=None, **kwargs):
         super().__init__(config)
         self.config = config
         self.max_width = config.max_width
@@ -83,12 +83,14 @@ class Extractor(PreTrainedModel):
         if tokenizer is not None:
             self.processor = SchemaTransformer(
                 tokenizer=tokenizer,
-                token_pooling=config.token_pooling
+                token_pooling=config.token_pooling,
+                **kwargs,
             )
         else:
             self.processor = SchemaTransformer(
                 config.model_name,
-                token_pooling=config.token_pooling
+                token_pooling=config.token_pooling,
+                **kwargs,
             )
 
         # Load encoder
@@ -681,6 +683,13 @@ class Extractor(PreTrainedModel):
             compile: If True, torch.compile the encoder and span-rep
                 with ``dynamic=True`` for fused GPU kernels.
             map_location: Device to load the model onto (e.g. "cpu", "cuda").
+            language: ISO 639-1 language code for text splitting.
+                When "ja", "zh" and "ko" use language-specific tokenizers
+                because whitespace splitting is insufficient.
+            ja_dict_type: For Japanese, specify the dictionary type
+                for text splitting (e.g., "small", "core", "full").
+            ja_split_mode: For Japanese, specify the split mode
+                for text splitting (e.g., "A", "B", "C").
             **kwargs: Additional keyword arguments.
 
         To use a LoRA adapter:
@@ -709,7 +718,7 @@ class Extractor(PreTrainedModel):
         encoder_config = AutoConfig.from_pretrained(encoder_config_path)
 
         tokenizer = AutoTokenizer.from_pretrained(repo_or_dir)
-        model = cls(config, encoder_config=encoder_config, tokenizer=tokenizer)
+        model = cls(config, encoder_config=encoder_config, tokenizer=tokenizer, **kwargs)
 
         # Load weights
         try:

--- a/gliner2/model.py
+++ b/gliner2/model.py
@@ -684,12 +684,12 @@ class Extractor(PreTrainedModel):
                 with ``dynamic=True`` for fused GPU kernels.
             map_location: Device to load the model onto (e.g. "cpu", "cuda").
             language: ISO 639-1 language code for text splitting.
-                When "ja", "zh" and "ko" use language-specific tokenizers
+                If "ja", "zh", "ko", use language-specific tokenizers
                 because whitespace splitting is insufficient.
             ja_dict_type: For Japanese, specify the dictionary type
-                for text splitting (e.g., "small", "core", "full").
+                for text splitting (e.g., "small", "core", "full". Default is "core").
             ja_split_mode: For Japanese, specify the split mode
-                for text splitting (e.g., "A", "B", "C").
+                for text splitting (e.g., "A", "B", "C". Default is "C").
             **kwargs: Additional keyword arguments.
 
         To use a LoRA adapter:

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -178,10 +178,13 @@ class ChineseTokenSplitter(TokenSplitter):
 
     def __init__(self) -> None:
         import logging
+        import warnings
         import jieba
 
         # Suppress jieba logging to avoid cluttering output.
-        jieba.setLogLevel(logging.ERROR)
+        warnings.filterwarnings("ignore", category=SyntaxWarning, module="jieba")
+        jieba.setLogLevel(logging.WARNING)
+
         self._tokenizer = jieba.Tokenizer()
 
     def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -8,9 +8,10 @@ via DataLoader collate functions for parallel preprocessing.
 import copy
 import random
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Dict, Tuple, Iterator, List, Optional
+from typing import Any, Dict, Literal, Tuple, Iterator, List, Optional
 import torch
 from transformers import AutoTokenizer
 
@@ -144,7 +145,15 @@ class PreprocessedBatch:
 # Tokenizer
 # =============================================================================
 
-class WhitespaceTokenSplitter:
+class TokenSplitter(ABC):
+    """Abstract base class for token splitters."""
+
+    @abstractmethod
+    def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
+        raise NotImplementedError("Subclasses must implement __call__ method.")
+
+
+class WhitespaceTokenSplitter(TokenSplitter):
     """Fast regex-based tokenizer for text splitting."""
     __slots__ = ()
 
@@ -162,6 +171,43 @@ class WhitespaceTokenSplitter:
             text = text.lower()
         for m in self._PATTERN.finditer(text):
             yield m.group(), m.start(), m.end()
+
+
+class JapaneseTokenSplitter(TokenSplitter):
+    """Morphological tokenizer for Japanese text splitting."""
+
+    def __init__(
+        self,
+        dict_type: Literal["small", "core", "full"] = "core",
+        split_mode: Literal["A", "B", "C"] = "C",
+    ) -> None:
+        from sudachipy import Dictionary
+        self._tokenizer = Dictionary(dict=dict_type).create(mode=split_mode)
+
+    def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
+        if lower:
+            text = text.lower()
+        for m in self._tokenizer.tokenize(text):
+            surface = m.surface()
+            if not surface.strip():
+                # Skip whitespace tokens to mirror the regex splitter.
+                continue
+
+            yield surface, m.begin(), m.end()
+
+
+def get_token_splitter(**kwargs) -> TokenSplitter:
+    """Get a token splitter based on the language (as ISO 639-1 code)."""
+
+    language = str(kwargs.get("language", "")).lower()
+
+    if language == "ja":
+        return JapaneseTokenSplitter(
+            dict_type=kwargs.get("ja_dict_type", "core"),
+            split_mode=kwargs.get("ja_split_mode", "C"),
+        )
+
+    return WhitespaceTokenSplitter()
 
 
 # =============================================================================
@@ -226,14 +272,15 @@ class SchemaTransformer:
             model_name: str = None,
             tokenizer=None,
             sampling_config: SamplingConfig = None,
-            token_pooling: str = "first"
+            token_pooling: str = "first",
+            **kwargs,
     ):
         if model_name is None and tokenizer is None:
             raise ValueError("Either model_name or tokenizer must be provided.")
 
         self.token_pooling = token_pooling if token_pooling in ["first", "mean", "max"] else "first"
         self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(model_name)
-        self.word_splitter = WhitespaceTokenSplitter()
+        self.word_splitter = get_token_splitter(**kwargs)
         self.sampling_config = sampling_config or SamplingConfig()
         self.is_training = False
 

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -181,7 +181,7 @@ class ChineseTokenSplitter(TokenSplitter):
         import jieba
 
         # Suppress jieba logging to avoid cluttering output.
-        jieba.setLogLevel(logging.WARNING)
+        jieba.setLogLevel(logging.ERROR)
         self._tokenizer = jieba.Tokenizer()
 
     def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -177,12 +177,13 @@ class ChineseTokenSplitter(TokenSplitter):
     """Morphological tokenizer for Chinese text splitting."""
 
     def __init__(self) -> None:
-        import logging
+        # Suppress jieba regex syntax warning.
         import warnings
-        import jieba
+        warnings.filterwarnings("ignore", category=SyntaxWarning, module="jieba")
 
         # Suppress jieba logging to avoid cluttering output.
-        warnings.filterwarnings("ignore", category=SyntaxWarning, module="jieba")
+        import logging
+        import jieba
         jieba.setLogLevel(logging.WARNING)
 
         self._tokenizer = jieba.Tokenizer()

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -179,7 +179,7 @@ class ChineseTokenSplitter(TokenSplitter):
     def __init__(self) -> None:
         # Suppress jieba regex syntax warning.
         import warnings
-        warnings.filterwarnings("ignore", category=SyntaxWarning, module="jieba")
+        warnings.filterwarnings("ignore", category=SyntaxWarning)
 
         # Suppress jieba logging to avoid cluttering output.
         import logging

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -150,7 +150,7 @@ class TokenSplitter(ABC):
 
     @abstractmethod
     def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
-        raise NotImplementedError("Subclasses must implement __call__ method.")
+        raise NotImplementedError
 
 
 class WhitespaceTokenSplitter(TokenSplitter):
@@ -196,8 +196,8 @@ class JapaneseTokenSplitter(TokenSplitter):
             yield surface, m.begin(), m.end()
 
 
-def get_token_splitter(**kwargs) -> TokenSplitter:
-    """Get a token splitter based on the language (as ISO 639-1 code)."""
+def resolve_token_splitter(**kwargs) -> TokenSplitter:
+    """Resolve a token splitter based on the ISO 639-1 language code."""
 
     language = str(kwargs.get("language", "")).lower()
 
@@ -280,7 +280,7 @@ class SchemaTransformer:
 
         self.token_pooling = token_pooling if token_pooling in ["first", "mean", "max"] else "first"
         self.tokenizer = tokenizer or AutoTokenizer.from_pretrained(model_name)
-        self.word_splitter = get_token_splitter(**kwargs)
+        self.word_splitter = resolve_token_splitter(**kwargs)
         self.sampling_config = sampling_config or SamplingConfig()
         self.is_training = False
 

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -228,7 +228,7 @@ class KoreanTokenSplitter(TokenSplitter):
 
     def __init__(self) -> None:
         from kiwipiepy import Kiwi
-        self._tokenizer = Kiwi()
+        self._tokenizer = Kiwi(load_multi_dict=False)
 
     def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
         from kiwipiepy import Token

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -173,6 +173,29 @@ class WhitespaceTokenSplitter(TokenSplitter):
             yield m.group(), m.start(), m.end()
 
 
+class ChineseTokenSplitter(TokenSplitter):
+    """Morphological tokenizer for Chinese text splitting."""
+
+    def __init__(self) -> None:
+        import logging
+        import jieba
+
+        # Suppress jieba logging to avoid cluttering output.
+        jieba.setLogLevel(logging.WARNING)
+        self._tokenizer = jieba.Tokenizer()
+
+    def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
+        if lower:
+            text = text.lower()
+        for m in self._tokenizer.tokenize(text):
+            surface = str(m[0])
+            if not surface.strip():
+                # Skip whitespace tokens to mirror the regex splitter.
+                continue
+
+            yield surface, int(m[1]), int(m[2])
+        
+
 class JapaneseTokenSplitter(TokenSplitter):
     """Morphological tokenizer for Japanese text splitting."""
 
@@ -201,7 +224,9 @@ def resolve_token_splitter(**kwargs) -> TokenSplitter:
 
     language = str(kwargs.get("language", "")).lower()
 
-    if language == "ja":
+    if language == "zh":
+        return ChineseTokenSplitter()
+    elif language == "ja":
         return JapaneseTokenSplitter(
             dict_type=kwargs.get("ja_dict_type", "core"),
             split_mode=kwargs.get("ja_split_mode", "C"),

--- a/gliner2/processor.py
+++ b/gliner2/processor.py
@@ -223,6 +223,30 @@ class JapaneseTokenSplitter(TokenSplitter):
             yield surface, m.begin(), m.end()
 
 
+class KoreanTokenSplitter(TokenSplitter):
+    """Morphological tokenizer for Korean text splitting."""
+
+    def __init__(self) -> None:
+        from kiwipiepy import Kiwi
+        self._tokenizer = Kiwi()
+
+    def __call__(self, text: str, lower: bool = True) -> Iterator[Tuple[str, int, int]]:
+        from kiwipiepy import Token
+
+        if lower:
+            text = text.lower()
+        for m in self._tokenizer.tokenize(text):
+            if not isinstance(m, Token):
+                # Skip non-Token results (e.g. list[Token], list[list[Token]]).
+                continue
+
+            if not m.form.strip():
+                # Skip whitespace tokens to mirror the regex splitter.
+                continue
+
+            yield m.form, m.start, m.end
+
+
 def resolve_token_splitter(**kwargs) -> TokenSplitter:
     """Resolve a token splitter based on the ISO 639-1 language code."""
 
@@ -235,6 +259,8 @@ def resolve_token_splitter(**kwargs) -> TokenSplitter:
             dict_type=kwargs.get("ja_dict_type", "core"),
             split_mode=kwargs.get("ja_split_mode", "C"),
         )
+    elif language == "ko":
+        return KoreanTokenSplitter()
 
     return WhitespaceTokenSplitter()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,16 +44,16 @@ local = [
     "peft",
 ]
 ja = [
-    "sudachidict-core>=20260428",
-    "sudachipy>=0.6.11",
+    "sudachidict-core",
+    "sudachipy",
 ]
 ja-small = [
-    "sudachidict-small>=20260428",
-    "sudachipy>=0.6.11",
+    "sudachidict-small",
+    "sudachipy",
 ]
 ja-full = [
-    "sudachidict-full>=20260428",
-    "sudachipy>=0.6.11",
+    "sudachidict-full",
+    "sudachipy",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ ja-full = [
 zh = [
     "jieba",
 ]
+ko = [
+    "kiwipiepy",
+]
 
 [project.urls]
 Homepage = "https://github.com/fastino-ai/GLiNER2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ ja-full = [
     "sudachidict-full",
     "sudachipy",
 ]
+zh = [
+    "jieba",
+]
 
 [project.urls]
 Homepage = "https://github.com/fastino-ai/GLiNER2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,18 @@ local = [
     "transformers",
     "peft",
 ]
+ja = [
+    "sudachidict-core>=20260428",
+    "sudachipy>=0.6.11",
+]
+ja-small = [
+    "sudachidict-small>=20260428",
+    "sudachipy>=0.6.11",
+]
+ja-full = [
+    "sudachidict-full>=20260428",
+    "sudachipy>=0.6.11",
+]
 
 [project.urls]
 Homepage = "https://github.com/fastino-ai/GLiNER2"


### PR DESCRIPTION
## Overview

Resolves #121 

## Note

To minimize the impact on existing users, I took the following measures.
- Added all the dependency libraries for each language to `project.optional-dependencies`.
  - Also, since people who want to work with Japanese don’t necessarily want to work with Chinese as well, I’ve divided the categories by language.
- I decided to reuse `**kwargs` without changing the API interface.
