### PR TITLE
add entity attribute

### DIFF
--- a/gliner2/__init__.py
+++ b/gliner2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 from .inference.schema import Schema, StructureBuilder, RegexValidator
 from .inference.schema_model import (
@@ -16,9 +16,11 @@ from .api_client import (
 )
 
 _LAZY = {
-    "GLiNER2":              ("gliner2.inference.engine", "GLiNER2"),
-    "Extractor":            ("gliner2.model",            "Extractor"),
-    "ExtractorConfig":      ("gliner2.model",            "ExtractorConfig"),
+    "GLiNER2":                  ("gliner2.inference.engine",          "GLiNER2"),
+    "Extractor":                ("gliner2.model",                     "Extractor"),
+    "ExtractorConfig":          ("gliner2.model",                     "ExtractorConfig"),
+    "EntityAttributeGLiNER2":   ("gliner2.inference.attribute_engine", "EntityAttributeGLiNER2"),
+    "AttributeGroup":           ("gliner2.inference.attribute_engine", "AttributeGroup"),
     "LoRAConfig":           ("gliner2.training.lora",    "LoRAConfig"),
     "LoRAAdapterConfig":    ("gliner2.training.lora",    "LoRAAdapterConfig"),
     "LoRALayer":            ("gliner2.training.lora",    "LoRALayer"),

--- a/gliner2/inference/attribute_engine.py
+++ b/gliner2/inference/attribute_engine.py
@@ -1,0 +1,398 @@
+"""
+EntityAttributeGLiNER2: assign attribute groups to extracted entity spans.
+
+Generalizes "entity-level sentiment" to arbitrary *attribute groups*. Each
+group is a set of entity-type labels that should be *assigned to* extracted
+spans rather than *extracted as* their own spans:
+
+* single-label group -> ``softmax`` over the group's label logits at the
+  span position, argmax -> exactly one value is forced on every span.
+* multi-label group -> ``sigmoid`` per label, keep those >= ``threshold``
+  (zero or more).
+
+Sentiment is just one configuration::
+
+    model = EntityAttributeGLiNER2.from_pretrained("repo")
+    model.set_attribute_groups({
+        "sentiment": AttributeGroup(["positive", "negative", "neutral"]),
+    })
+    # Note: the user does NOT add sentiment labels to the schema.
+    schema = model.create_schema().entities(["person", "company", "product"])
+    model.extract(text, schema, format_results=False)
+
+Attribute labels are *not* declared in the schema by the user. The engine
+injects them into the entity set automatically at inference time (so the
+model scores them), then consumes them as span attributes instead of
+emitting them as their own entity buckets. Injection only happens for
+schemas that already contain an entity task.
+
+The engine overrides only the ``entities`` decode path; classifications,
+structures and relations fall through to :class:`GLiNER2` unchanged.
+
+Note
+----
+Read results with ``extract(..., format_results=False)``. The base
+``format_results`` / ``_format_entity_dict`` reshape entity dicts and will
+drop the extra attribute keys otherwise.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+
+from gliner2.inference.engine import GLiNER2
+from gliner2.inference.schema import Schema
+
+
+@dataclass
+class AttributeGroup:
+    """A group of entity-type labels to *assign* to spans, not extract as spans.
+
+    Args:
+        labels: Group labels. Mutually exclusive when ``multi_label`` is False.
+        multi_label: If False, softmax over labels (forced exactly one). If
+            True, sigmoid per label and keep those >= ``threshold``.
+        threshold: Selection cutoff, only used when ``multi_label`` is True.
+        applies_to: Entity types this group annotates. ``None`` means every
+            content entity type.
+    """
+
+    labels: List[str]
+    multi_label: bool = False
+    threshold: float = 0.5
+    applies_to: Optional[List[str]] = None
+
+
+class EntityAttributeGLiNER2(GLiNER2):
+    """GLiNER2 variant that assigns softmax/sigmoid attribute groups to spans."""
+
+    #: Keys the engine writes on every span dict; a group name that collides
+    #: with one of these would silently overwrite the entity's own fields.
+    _RESERVED_NAMES = frozenset({"text", "confidence", "start", "end"})
+
+    def set_attribute_groups(
+        self, groups: Dict[str, AttributeGroup]
+    ) -> "EntityAttributeGLiNER2":
+        """Register attribute groups. Label sets must be disjoint across groups."""
+        groups = groups or {}
+        seen: Dict[str, str] = {}
+        for gname, g in groups.items():
+            if not gname or gname in self._RESERVED_NAMES:
+                raise ValueError(
+                    f"Invalid attribute group name {gname!r}: must be non-empty "
+                    f"and not one of {sorted(self._RESERVED_NAMES)}"
+                )
+            if not g.labels:
+                raise ValueError(f"Attribute group '{gname}' has no labels")
+            if not 0.0 <= g.threshold <= 1.0:
+                raise ValueError(
+                    f"Attribute group '{gname}' threshold must be in [0, 1], "
+                    f"got {g.threshold}"
+                )
+            group_seen: set = set()
+            for lbl in g.labels:
+                if not lbl or not lbl.strip():
+                    raise ValueError(f"Attribute group '{gname}' has an empty label")
+                if lbl in group_seen:
+                    raise ValueError(
+                        f"Label '{lbl}' is duplicated within group '{gname}'"
+                    )
+                group_seen.add(lbl)
+                if lbl in seen:
+                    raise ValueError(
+                        f"Label '{lbl}' is in both '{seen[lbl]}' and '{gname}'"
+                    )
+                seen[lbl] = gname
+        self._attr_groups: Dict[str, AttributeGroup] = groups
+        self._attr_labels: set = set(seen)
+        return self
+
+    @property
+    def _groups(self) -> Dict[str, AttributeGroup]:
+        return getattr(self, "_attr_groups", {})
+
+    # =========================================================================
+    # Schema augmentation — inject attribute labels so the model scores them
+    # =========================================================================
+
+    def batch_extract(self, texts, schemas, *args, **kwargs):
+        """Inject attribute labels into schemas, then run base extraction."""
+        if self._groups and self._attr_labels:
+            schemas = self._inject_attribute_labels(schemas)
+        return super().batch_extract(texts, schemas, *args, **kwargs)
+
+    def _inject_attribute_labels(
+        self, schemas: Union[Schema, Dict, List]
+    ) -> Union[Schema, Dict, List]:
+        labels = sorted(self._attr_labels)
+        if isinstance(schemas, list):
+            return [self._augment_schema(s, labels) for s in schemas]
+        return self._augment_schema(schemas, labels)
+
+    @staticmethod
+    def _augment_schema(schema, labels: List[str]):
+        """Add missing attribute labels to a schema's entity set.
+
+        Only augments schemas that already declare an entity task, so a
+        pure-classification/structure schema is never turned into an entity
+        extractor. Returns a copy; the caller's schema is left untouched.
+        """
+        # Schema builder object
+        if isinstance(schema, Schema) or (
+            hasattr(schema, "build") and hasattr(schema, "entities")
+        ):
+            existing = set(schema.schema.get("entities", {})) if hasattr(schema, "schema") else set()
+            if not existing:
+                return schema  # no entity task -> nothing to attach attributes to
+            missing = [lbl for lbl in labels if lbl not in existing]
+            if not missing:
+                return schema
+            schema = copy.deepcopy(schema)
+            schema.entities(missing)
+            return schema
+
+        # Dict schema
+        if isinstance(schema, dict):
+            ents = schema.get("entities")
+            if not ents:
+                return schema
+            new_schema = dict(schema)
+            if isinstance(ents, list):
+                new_schema["entities"] = list(ents) + [
+                    lbl for lbl in labels if lbl not in ents
+                ]
+            elif isinstance(ents, dict):
+                new_ents = dict(ents)
+                for lbl in labels:
+                    new_ents.setdefault(lbl, "")
+                new_schema["entities"] = new_ents
+            return new_schema
+
+        return schema
+
+    # =========================================================================
+    # Entity decode override
+    # =========================================================================
+
+    def _extract_span_result(
+        self,
+        results,
+        schema_name,
+        task_type,
+        embs,
+        span_info,
+        schema_tokens,
+        text_tokens,
+        text_len,
+        original_text,
+        start_mapping,
+        end_mapping,
+        threshold,
+        metadata,
+        cls_fields,
+        include_confidence,
+        include_spans,
+    ):
+        # Only entities get attribute assignment; everything else is unchanged.
+        if schema_name != "entities" or not self._groups:
+            return super()._extract_span_result(
+                results,
+                schema_name,
+                task_type,
+                embs,
+                span_info,
+                schema_tokens,
+                text_tokens,
+                text_len,
+                original_text,
+                start_mapping,
+                end_mapping,
+                threshold,
+                metadata,
+                cls_fields,
+                include_confidence,
+                include_spans,
+            )
+
+        field_names: List[str] = []
+        for j in range(len(schema_tokens) - 1):
+            if schema_tokens[j] in ("[E]", "[C]", "[R]"):
+                field_names.append(schema_tokens[j + 1])
+        if not field_names:
+            results["entities"] = []
+            return
+
+        count_logits = self.count_pred(embs[0].unsqueeze(0))
+        pred_count = int(count_logits.argmax(dim=1).item())
+        if pred_count <= 0 or span_info is None:
+            results["entities"] = []
+            return
+
+        struct_proj = self.count_embed(embs[1:], pred_count)
+        # Keep the pre-sigmoid logits: needed to softmax within an attribute
+        # group. Sigmoid is still used for the entity-detection threshold.
+        raw_logits = torch.einsum(
+            "lkd,bpd->bplk", span_info["span_rep"], struct_proj
+        )
+        span_scores = torch.sigmoid(raw_logits)
+
+        results["entities"] = self._extract_entities_with_attributes(
+            field_names,
+            span_scores,
+            raw_logits,
+            text_len,
+            original_text,
+            start_mapping,
+            end_mapping,
+            threshold,
+            metadata,
+            include_confidence,
+            include_spans,
+        )
+
+    def _extract_entities_with_attributes(
+        self,
+        entity_names: List[str],
+        span_scores: torch.Tensor,
+        raw_logits: torch.Tensor,
+        text_len: int,
+        text: str,
+        start_map: List[int],
+        end_map: List[int],
+        threshold: float,
+        metadata: Dict,
+        include_confidence: bool,
+        include_spans: bool,
+    ) -> List[Dict]:
+        # Precompute per-group label -> field-index tensors, dropping labels
+        # that are not present in this schema's entity set.
+        group_idx: Dict[str, Any] = {}
+        for gname, g in self._groups.items():
+            present = [
+                (lbl, entity_names.index(lbl))
+                for lbl in g.labels
+                if lbl in entity_names
+            ]
+            if present:
+                labels, idxs = zip(*present)
+                group_idx[gname] = (
+                    list(labels),
+                    torch.tensor(idxs, device=raw_logits.device),
+                    g,
+                )
+
+        content_names = [n for n in entity_names if n not in self._attr_labels]
+
+        scores = span_scores[0, :, -text_len:]  # (n_fields, L, K) sigmoid — detection
+        logits = raw_logits[0, :, -text_len:]  # (n_fields, L, K) raw — attributes
+
+        entity_results: "OrderedDict[str, Any]" = OrderedDict()
+        for name in metadata.get("entity_order", content_names):
+            if name not in content_names:
+                continue
+            idx = entity_names.index(name)
+            meta = metadata.get("entity_metadata", {}).get(name, {})
+            # An explicit per-entity threshold of 0.0 is valid and must not fall
+            # back to the global threshold, so check for None instead of falsiness.
+            configured = meta.get("threshold")
+            ent_threshold = threshold if configured is None else configured
+
+            starts, widths = torch.where(scores[idx] >= ent_threshold)
+            found: List[Dict[str, Any]] = []
+            for start, width in zip(starts.tolist(), widths.tolist()):
+                end = start + width + 1
+                if not (0 <= start < text_len and end <= text_len):
+                    continue
+                try:
+                    cs, ce = start_map[start], end_map[end - 1]
+                    span_text = text[cs:ce].strip()
+                except (IndexError, KeyError):
+                    continue
+                if not span_text:
+                    continue
+
+                attrs = self._assign_attributes(logits, start, width, group_idx, name)
+                # start/end/confidence are always kept here so _dedupe can run;
+                # _format_entity trims them afterwards to honour the public flags.
+                found.append(
+                    {
+                        "text": span_text,
+                        "confidence": scores[idx, start, width].item(),
+                        "start": cs,
+                        "end": ce,
+                        **attrs,
+                    }
+                )
+
+            entity_results[name] = [
+                self._format_entity(d, include_confidence, include_spans)
+                for d in self._dedupe(found)
+            ]
+
+        return [entity_results] if entity_results else []
+
+    @staticmethod
+    def _assign_attributes(
+        logits: torch.Tensor,
+        start: int,
+        width: int,
+        group_idx: Dict[str, Any],
+        entity_name: str,
+    ) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for gname, (labels, idxs, g) in group_idx.items():
+            if g.applies_to is not None and entity_name not in g.applies_to:
+                continue  # group not scoped to this entity type
+            vec = logits[idxs, start, width]  # (n_labels_in_group,)
+            if g.multi_label:
+                probs = torch.sigmoid(vec)
+                out[gname] = [
+                    {"label": labels[i], "confidence": probs[i].item()}
+                    for i in range(len(labels))
+                    if probs[i].item() >= g.threshold
+                ]
+            else:
+                probs = torch.softmax(vec, dim=-1)  # forced: always sums to 1
+                b = int(probs.argmax())
+                out[gname] = {"label": labels[b], "confidence": probs[b].item()}
+        return out
+
+    @staticmethod
+    def _dedupe(found: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        found.sort(key=lambda d: d["confidence"], reverse=True)
+        kept: List[Dict[str, Any]] = []
+        for d in found:
+            if not any(
+                not (d["end"] <= k["start"] or d["start"] >= k["end"]) for k in kept
+            ):
+                kept.append(d)
+        return kept
+
+    @staticmethod
+    def _format_entity(
+        entity: Dict[str, Any],
+        include_confidence: bool,
+        include_spans: bool,
+    ) -> Dict[str, Any]:
+        """Trim internal span fields to honour the public output flags.
+
+        ``text`` and any attribute-group payloads are always kept; ``confidence``
+        and ``start``/``end`` are only emitted when explicitly requested, matching
+        the base :class:`GLiNER2` contract.
+        """
+        reserved = EntityAttributeGLiNER2._RESERVED_NAMES
+        out: Dict[str, Any] = {"text": entity["text"]}
+        if include_confidence:
+            out["confidence"] = entity["confidence"]
+        if include_spans:
+            out["start"] = entity["start"]
+            out["end"] = entity["end"]
+        for key, value in entity.items():
+            if key not in reserved:
+                out[key] = value
+        return out

--- a/gliner2/inference/chunking.py
+++ b/gliner2/inference/chunking.py
@@ -35,9 +35,14 @@ class TextChunk:
 
 
 def iter_word_offsets(text: str) -> Iterable[Tuple[str, int, int]]:
-    """Yield regex word tokens and character offsets using processor-compatible rules."""
-    lowered = text.lower()
-    for match in _WORD_PATTERN.finditer(lowered):
+    """Yield regex word tokens and character offsets using processor-compatible rules.
+
+    The regex is matched against the original text (it is already case-insensitive)
+    so that the reported offsets index the caller's string. Lower-casing before
+    matching is unsafe because Unicode case folding can change string length
+    (e.g. ``"İ".lower()`` expands to two code points), which would shift offsets.
+    """
+    for match in _WORD_PATTERN.finditer(text):
         yield match.group(), match.start(), match.end()
 
 
@@ -113,20 +118,30 @@ def merge_chunk_results(
     chunk_results: List[Dict[str, Any]],
     include_confidence: bool = False,
     include_spans: bool = False,
+    scalar_entity_labels: Optional[Iterable[str]] = None,
 ) -> Dict[str, Any]:
-    """Merge formatted extraction results from one document's chunks."""
+    """Merge formatted extraction results from one document's chunks.
+
+    ``scalar_entity_labels`` names entity types declared with a non-list dtype;
+    those are collapsed to a single best value (mirroring the base API) instead
+    of being returned as a list.
+    """
     if len(chunks) != len(chunk_results):
         raise ValueError("chunks and chunk_results must have the same length")
 
+    scalar_labels = set(scalar_entity_labels or ())
     remapped_results = [
         remap_result_spans(result, original_text, chunk)
         for chunk, result in zip(chunks, chunk_results)
     ]
-    merged = _merge_result_dicts(remapped_results)
+    merged = _merge_result_dicts(remapped_results, scalar_labels)
     return _strip_span_metadata(merged, include_confidence, include_spans)
 
 
-def _merge_result_dicts(results: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _merge_result_dicts(
+    results: List[Dict[str, Any]],
+    scalar_entity_labels: Optional[set] = None,
+) -> Dict[str, Any]:
     merged: Dict[str, Any] = {}
     keys = []
     seen = set()
@@ -139,7 +154,7 @@ def _merge_result_dicts(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     for key in keys:
         values = [result.get(key) for result in results if key in result]
         if key == "entities":
-            merged[key] = _merge_entity_maps(values)
+            merged[key] = _merge_entity_maps(values, scalar_entity_labels or set())
         elif key == "relation_extraction":
             merged[key] = _merge_relation_maps(values)
         else:
@@ -148,7 +163,7 @@ def _merge_result_dicts(results: List[Dict[str, Any]]) -> Dict[str, Any]:
     return merged
 
 
-def _merge_entity_maps(values: List[Any]) -> Dict[str, Any]:
+def _merge_entity_maps(values: List[Any], scalar_labels: set) -> Dict[str, Any]:
     merged: Dict[str, Any] = {}
     labels = []
     seen = set()
@@ -165,7 +180,13 @@ def _merge_entity_maps(values: List[Any]) -> Dict[str, Any]:
         for value in values:
             if isinstance(value, dict) and label in value:
                 items.extend(_as_list(value[label]))
-        merged[label] = _dedupe_items(items, remove_overlaps=True)
+        deduped = _dedupe_items(items, remove_overlaps=True)
+        if label in scalar_labels:
+            # A non-list entity dtype yields a single best value (or None),
+            # matching the base engine's scalar contract.
+            merged[label] = deduped[0] if deduped else None
+        else:
+            merged[label] = deduped
 
     return merged
 
@@ -250,14 +271,27 @@ def _dedupe_items(items: List[Any], remove_overlaps: bool) -> List[Any]:
             selected.append(item)
         deduped.extend(sorted(selected, key=lambda item: (item["start"], item["end"], item.get("text", ""))))
 
-    seen_other = set()
+    # Non-span items (relations, structure instances, classification dicts) are
+    # deduplicated on a confidence-insensitive canonical key so that the same
+    # prediction seen in two overlapping chunks with slightly different scores is
+    # collapsed. When a duplicate is found, the higher-confidence one is kept.
+    seen_other: Dict[str, int] = {}
+    other_deduped: List[Any] = []
     for item in other_items:
         key = _canonical_key(item)
         if key not in seen_other:
-            seen_other.add(key)
-            deduped.append(item)
+            seen_other[key] = len(other_deduped)
+            other_deduped.append(item)
+        else:
+            idx = seen_other[key]
+            if _representative_confidence(item) > _representative_confidence(other_deduped[idx]):
+                other_deduped[idx] = item
+    deduped.extend(other_deduped)
 
     return deduped
+
+
+_SPAN_RESERVED = frozenset({"text", "confidence", "start", "end"})
 
 
 def _strip_span_metadata(value: Any, include_confidence: bool, include_spans: bool) -> Any:
@@ -266,15 +300,35 @@ def _strip_span_metadata(value: Any, include_confidence: bool, include_spans: bo
 
     if isinstance(value, dict):
         if _is_span_dict(value):
-            if not include_confidence and not include_spans:
+            # Entity spans may carry extra attribute-group payloads (e.g.
+            # ``{"text": ..., "sentiment": {...}}``). Those extra keys must be
+            # preserved verbatim to match the non-long attribute API, which keeps
+            # attribute payloads regardless of the confidence/span flags.
+            extras = {k: v for k, v in value.items() if k not in _SPAN_RESERVED}
+            if not include_confidence and not include_spans and not extras:
                 return value.get("text", "")
-            stripped = {"text": value.get("text", "")}
+            stripped: Dict[str, Any] = {"text": value.get("text", "")}
             if include_confidence and "confidence" in value:
                 stripped["confidence"] = value["confidence"]
             if include_spans:
                 stripped["start"] = value["start"]
                 stripped["end"] = value["end"]
+            stripped.update(extras)
             return stripped
+
+        # Classification results, e.g. ``{"label": "positive", "confidence": ...}``.
+        if _is_classification_dict(value):
+            if include_confidence:
+                return {"label": value["label"], "confidence": value["confidence"]}
+            return value["label"]
+
+        # Enum/choice structure fields, e.g. ``{"text": "outdoor", "confidence": ...}``
+        # (a text/confidence pair with no character offsets).
+        if "text" in value and "confidence" in value and "start" not in value and "end" not in value:
+            if include_confidence:
+                return {"text": value["text"], "confidence": value["confidence"]}
+            return value["text"]
+
         return {
             key: _strip_span_metadata(item, include_confidence, include_spans)
             for key, item in value.items()
@@ -316,7 +370,27 @@ def _spans_overlap(left: Dict[str, Any], right: Dict[str, Any]) -> bool:
 
 def _canonical_key(value: Any) -> str:
     if isinstance(value, dict):
-        return repr(sorted((key, _canonical_key(item)) for key, item in value.items()))
+        return repr(
+            sorted(
+                (key, _canonical_key(item))
+                for key, item in value.items()
+                if key != "confidence"
+            )
+        )
     if isinstance(value, list):
         return repr([_canonical_key(item) for item in value])
     return repr(value)
+
+
+def _representative_confidence(value: Any) -> float:
+    """Best-effort confidence for a possibly-nested prediction, used to pick the
+    survivor when duplicate predictions are merged across overlapping chunks."""
+    if isinstance(value, dict):
+        if isinstance(value.get("confidence"), (int, float)):
+            return float(value["confidence"])
+        nested = [_representative_confidence(v) for v in value.values()]
+        return max(nested) if nested else 0.0
+    if isinstance(value, list):
+        nested = [_representative_confidence(v) for v in value]
+        return max(nested) if nested else 0.0
+    return 0.0

--- a/gliner2/inference/engine.py
+++ b/gliner2/inference/engine.py
@@ -161,9 +161,18 @@ class GLiNER2(Extractor):
                     "classification_tasks": classification_tasks
                 }
 
-            # Ensure classifications have true_label
-            for cls_config in schema_dict.get("classifications", []):
-                cls_config.setdefault("true_label", ["N/A"])
+            # Ensure classifications have true_label without mutating a
+            # caller-owned dict schema in place. Only rebuild the configs that
+            # are missing the key, and only replace schema_dict if needed.
+            classifications = schema_dict.get("classifications")
+            if classifications and any("true_label" not in c for c in classifications):
+                schema_dict = {
+                    **schema_dict,
+                    "classifications": [
+                        c if "true_label" in c else {**c, "true_label": ["N/A"]}
+                        for c in classifications
+                    ],
+                }
 
             schema_dicts.append(schema_dict)
             metadata_list.append(metadata)
@@ -337,6 +346,36 @@ class GLiNER2(Extractor):
 
         return results
 
+    @staticmethod
+    def _resolve_classification_config(
+        prompt_str: str,
+        classifications: List[Dict]
+    ) -> Optional[Dict]:
+        """Find the classification config that owns ``prompt_str``.
+
+        A config matches when ``prompt_str`` equals its task name or is followed
+        by a word/prompt boundary (end of string, ``":"`` for a prompt, or a
+        space before description/example decorations). The longest matching task
+        wins so that prefixes like "sent" cannot shadow "sentiment".
+        """
+        best = None
+        for config in classifications:
+            task = config.get("task", "")
+            if not task or not prompt_str.startswith(task):
+                continue
+            rest = prompt_str[len(task):]
+            if rest == "" or rest[0] in (":", " "):
+                if best is None or len(task) > len(best.get("task", "")):
+                    best = config
+        if best is None:
+            # Fall back to the original loose prefix match to avoid crashing on
+            # unexpected decorations rather than returning nothing.
+            best = next(
+                (c for c in classifications if prompt_str.startswith(c.get("task", ""))),
+                None,
+            )
+        return best
+
     def _extract_classification_result(
         self,
         results: Dict,
@@ -346,10 +385,16 @@ class GLiNER2(Extractor):
         schema_tokens: List[str]
     ):
         """Extract classification result."""
-        cls_config = next(
-            c for c in schema["classifications"]
-            if schema_tokens[2].startswith(c["task"])
-        )
+        # ``schema_tokens[2]`` is the prompt string, which may be decorated as
+        # "<task>", "<task>: <prompt>" and/or followed by description/example
+        # tokens. Resolve the owning task by boundary-aware longest match so that
+        # tasks sharing a prefix (e.g. "sent" vs "sentiment") are never confused,
+        # and key the result by the exact task name so prompts don't leak into it.
+        prompt_str = schema_tokens[2]
+        cls_config = self._resolve_classification_config(prompt_str, schema.get("classifications", []))
+        if cls_config is None:
+            return
+        schema_name = cls_config["task"]
 
         cls_embeds = embs[1:]
         logits = self.classifier(cls_embeds).squeeze(-1)
@@ -759,10 +804,17 @@ class GLiNER2(Extractor):
             return [s[0] for s in selected]
 
     def _find_choice_idx(self, choice: str, tokens: List[str]) -> int:
-        """Find index of choice in tokens."""
+        """Find index of choice in tokens.
+
+        Choices are inserted into the classification prefix verbatim as single
+        tokens, so an exact (case-insensitive) match is correct. The previous
+        substring fallback (``choice_lower in tok.lower()``) is unsafe: a short
+        choice such as "in" would spuriously match a prefix token like "seating"
+        and read the score from the wrong position.
+        """
         choice_lower = choice.lower()
         for i, tok in enumerate(tokens):
-            if tok.lower() == choice_lower or choice_lower in tok.lower():
+            if tok.lower() == choice_lower:
                 return i
         return -1
 
@@ -875,10 +927,17 @@ class GLiNER2(Extractor):
                             seen.add((text.lower(), start, end))
                             unique.append({"text": text, "confidence": conf} if include_confidence else text)
                     elif isinstance(span, dict):
-                        # Handle dict format (with confidence/spans)
+                        # Handle dict format (with confidence/spans). Include the
+                        # character offsets in the dedup key when present so that
+                        # distinct occurrences of the same surface form (e.g.
+                        # "John met John.") are not collapsed into one.
                         text = span.get("text", "")
-                        if text and text.lower() not in seen:
-                            seen.add(text.lower())
+                        if "start" in span and "end" in span:
+                            key = (text.lower(), span["start"], span["end"])
+                        else:
+                            key = (text.lower(), None, None)
+                        if text and key not in seen:
+                            seen.add(key)
                             unique.append(span)
                     else:
                         # Handle string format
@@ -906,10 +965,16 @@ class GLiNER2(Extractor):
                             seen.add((text.lower(), start, end))
                             unique.append({"text": text, "confidence": conf} if include_confidence else text)
                     elif isinstance(v, dict):
-                        # Handle dict format (with confidence/spans)
+                        # Handle dict format (with confidence/spans). Include the
+                        # character offsets in the dedup key when present so that
+                        # distinct occurrences of the same surface form are kept.
                         text = v.get("text", "")
-                        if text and text.lower() not in seen:
-                            seen.add(text.lower())
+                        if "start" in v and "end" in v:
+                            key = (text.lower(), v["start"], v["end"])
+                        else:
+                            key = (text.lower(), None, None)
+                        if text and key not in seen:
+                            seen.add(key)
                             unique.append(v)
                     else:
                         # Handle string format
@@ -1021,7 +1086,7 @@ class GLiNER2(Extractor):
 
         merged_results: List[Dict[str, Any]] = []
         offset = 0
-        for text, chunks, count in zip(texts, doc_chunks, doc_chunk_counts):
+        for text, schema, chunks, count in zip(texts, schema_list, doc_chunks, doc_chunk_counts):
             results_for_doc = chunk_results[offset:offset + count]
             merged_results.append(
                 merge_chunk_results(
@@ -1030,11 +1095,28 @@ class GLiNER2(Extractor):
                     results_for_doc,
                     include_confidence=include_confidence,
                     include_spans=include_spans,
+                    scalar_entity_labels=self._scalar_entity_labels(schema),
                 )
             )
             offset += count
 
         return merged_results
+
+    @staticmethod
+    def _scalar_entity_labels(schema) -> set:
+        """Names of entity types declared with a non-list dtype.
+
+        Only ``Schema`` objects carry this metadata; raw dict schemas don't, so
+        they default to list semantics (an empty set).
+        """
+        entity_metadata = getattr(schema, "_entity_metadata", None)
+        if not isinstance(entity_metadata, dict):
+            return set()
+        return {
+            name
+            for name, meta in entity_metadata.items()
+            if isinstance(meta, dict) and meta.get("dtype", "list") != "list"
+        }
 
     def extract_entities(self, text: str, entity_types, threshold: float = 0.5,
                         format_results: bool = True, include_confidence: bool = False,


### PR DESCRIPTION
# Inference engine correctness fixes + entity attribute engine

## Summary

This PR does two things:

1. **Adds `EntityAttributeGLiNER2`** — a new inference engine that assigns
   *attribute groups* (e.g. sentiment) to extracted entity spans instead of
   emitting them as separate entity buckets.
2. **Fixes a batch of correctness bugs** in the shared inference stack
   (`engine.py`, `chunking.py`, `processor.py`) that affected span offsets,
   long-document merging, classification decoding, and entity deduplication.

No public API signatures were removed; all changes are behavior-preserving for
correct inputs and only alter previously-broken paths.

---

## New feature: `EntityAttributeGLiNER2`

`gliner2/inference/attribute_engine.py` (+ exports for `EntityAttributeGLiNER2`
and `AttributeGroup` in `gliner2/__init__.py`).

### What it does

Generalizes "entity-level sentiment" into arbitrary **attribute groups**. An
attribute group is a set of labels that should be *assigned to* extracted spans
rather than *extracted as* their own spans.

```python
from gliner2 import EntityAttributeGLiNER2, AttributeGroup

model = EntityAttributeGLiNER2.from_pretrained("repo")
model.set_attribute_groups({
    "sentiment": AttributeGroup(["positive", "negative", "neutral"]),
})

# The user does NOT add sentiment labels to the schema.
schema = model.create_schema().entities(["person", "company", "product"])
result = model.extract(text, schema, format_results=False)
# -> {"entities": {"company": [{"text": "Apple", "sentiment": {"label": "positive", ...}}]}}
```

### Design

- **Automatic label injection.** Attribute labels are never declared by the
  user. `batch_extract` injects them into the entity set at inference time (so
  the model scores them), and only for schemas that already contain an entity
  task — a pure classification/structure schema is never turned into an entity
  extractor. The caller's schema is deep-copied, not mutated.
- **Scoring.** Single-label groups take a `softmax` over the group's label
  logits at the span position (exactly one value forced); multi-label groups
  use per-label `sigmoid` and keep those `>= threshold`. Entity *detection*
  still uses the sigmoid score against the entity threshold.
- **Minimal override surface.** Only the `entities` decode path is overridden;
  classifications, structures, and relations fall through to `GLiNER2`
  unchanged.
- **Validation.** `set_attribute_groups` enforces non-empty/reserved-safe group
  names (`text`/`confidence`/`start`/`end` are reserved), disjoint label sets
  across groups, no duplicate labels within a group, and thresholds in `[0, 1]`.
- **Scoped groups.** `AttributeGroup.applies_to` restricts a group to specific
  entity types; `None` applies to all content entities.

---

## Bug fixes

### 1. Unicode-unsafe character offsets
`processor.py` (`WhitespaceTokenSplitter`) and `chunking.py`
(`iter_word_offsets`) lower-cased the text *before* recording regex offsets.
Unicode case folding can change string length (e.g. `"İ".lower()` expands to
two code points), so the recorded `start`/`end` no longer indexed the caller's
string. Both tokenizers now match against the original text (the pattern is
already case-insensitive) and lower-case only the returned token value.

### 2. Long-document extraction dropped entity attributes
`chunking._strip_span_metadata` rebuilt each span with only
`text`/`confidence`/`start`/`end`, discarding attribute payloads such as
`sentiment`. Attribute keys on span dicts are now preserved verbatim, so the
attribute engine is compatible with the inherited long-document API.

### 3. Long-document results leaked confidence / duplicated labels
When `include_confidence=False`, classification dicts (`{"label", "confidence"}`)
and enum/choice dicts (`{"text", "confidence"}`) were returned unchanged because
they aren't span dicts. `_strip_span_metadata` now normalizes them to bare
labels/strings (or keeps confidence when requested), matching the base API.

### 4. Overlapping chunks produced duplicate relations/structures
`_canonical_key` included nested `confidence` values, so the same prediction
seen in two overlapping chunks with slightly different scores survived twice.
The key is now confidence-insensitive and `_dedupe_items` keeps the
higher-confidence survivor.

### 5. Scalar entity dtype was lost in long extraction
`_merge_entity_maps` always returned a list. Entity types declared with a
non-list `dtype` are now collapsed to a single best value via a new
`scalar_entity_labels` argument threaded from `batch_extract_long`.

### 6. Ambiguous classification task matching
`_extract_classification_result` selected the config with
`schema_tokens[2].startswith(task)`, so `"sent"` could shadow `"sentiment"`
(wrong labels, wrong activation, or an `IndexError` swallowed into `{}`). Added
`_resolve_classification_config`, a boundary-aware longest-match resolver.

### 7. Classification prompt leaked into the result key
The result was keyed by the raw prompt string, so a task with a `prompt` or
description was returned under e.g. `"sentiment: Judge the tone"` and missed the
`classification_tasks` check. Results are now keyed by the exact task name.

### 8. Repeated entity mentions collapsed
`_format_entity_dict` and `_format_struct` deduplicated dict-form spans by
`text.lower()` only, so `"John met John."` lost the second mention when spans
were requested. The dedup key now includes `start`/`end` when present.

### 9. Unsafe choice-token matching
`_find_choice_idx` accepted a substring match (`choice in token`), so a short
choice like `"in"` matched a prefix token like `"seating"` and read the score
from the wrong position. Since choices are inserted verbatim as single prefix
tokens, matching is now exact.

### 10. `batch_extract` mutated caller-owned dict schemas
Defaulting `true_label` via `setdefault` mutated the caller's nested
classification dicts in place. Configs are now rebuilt copy-on-write only when
the key is missing.

---

## Files changed

| File | Change |
| --- | --- |
| `gliner2/inference/attribute_engine.py` | New attribute engine (`EntityAttributeGLiNER2`, `AttributeGroup`) |
| `gliner2/__init__.py` | Lazy exports for the new classes |
| `gliner2/inference/chunking.py` | Unicode offsets, attribute-preserving strip, confidence-insensitive dedup, scalar entity merge |
| `gliner2/inference/engine.py` | Classification task resolver, offset-aware entity/struct dedup, exact choice match, non-mutating schema normalization, scalar-label threading |
| `gliner2/processor.py` | Unicode-safe tokenizer offsets |

---

## Test plan

- [x] `tests/test_long_document_chunking.py` — 7 passed
- [x] `tests/test_long_document_extraction.py` — 4 passed, 1 skipped (slow)
- [x] `tests/test_entity_extraction.py`, `test_structure_extraction.py`,
      `test_relation_extraction.py`, `test_batching_correctness.py`,
      `test_inference_max_len.py` — all passed
- [x] Targeted checks: classification resolver disambiguates `sent`/`sentiment`
      across prompts/descriptions; attribute payloads survive strip; choice/
      classification confidence stripped when disabled; overlapping duplicate
      relations collapse to the higher-confidence instance
- [ ] `tests/test_backwards_compat.py` LoRA cases are unrelated and fail only
      due to missing `tests/fixtures/compat/*.pt` fixtures in this checkout

---

## Follow-ups (not in this PR)

Known issues that need a separate, more invasive change:

- `Schema.to_dict()` / `from_dict()` round-trip drops thresholds, validators,
  and per-entity dtype.
- Public dict schemas using `"structures"` are ignored by inference (it only
  reads the internal `"json_structures"` form).
- `num_workers > 0` likely breaks under spawn start (macOS/Windows) due to the
  pickled `lru_cache` on the processor.
- Preprocessing/decoding exceptions are silently swallowed into a `"dummy"`
  task or `{}`.
- Empty / non-terminal-punctuation input is rewritten (`"" -> "."`), which can
  yield offsets outside the caller's original string.
- Attribute engine ignores scalar entity dtype, and an entity type that
  collides with an attribute label is silently suppressed.
