### PR TITLE
Support per-field thresholds & regex validators in JSON schema (from_dict), plus per-task cls_threshold

### DIFF
--- a/gliner2/__init__.py
+++ b/gliner2/__init__.py
@@ -6,6 +6,7 @@ from .inference.schema_model import (
     FieldInput,
     StructureInput,
     ClassificationInput,
+    ValidatorInput,
 )
 from .api_client import (
     GLiNER2API,

--- a/gliner2/inference/schema.py
+++ b/gliner2/inference/schema.py
@@ -52,6 +52,19 @@ class RegexValidator:
         return not matched if self.exclude else matched
 
 
+def _validator_to_dict(validator: "RegexValidator") -> Dict[str, Any]:
+    """Serialize a RegexValidator to the JSON form accepted by from_dict()."""
+    pattern = validator.pattern
+    if isinstance(pattern, re.Pattern):
+        pattern = pattern.pattern
+    return {
+        "pattern": pattern,
+        "mode": validator.mode,
+        "exclude": validator.exclude,
+        "ignore_case": bool(validator.flags & re.IGNORECASE),
+    }
+
+
 # =============================================================================
 # Schema Builder
 # =============================================================================
@@ -305,11 +318,24 @@ class Schema:
             for struct_name, struct_input in validated.structures.items():
                 builder = schema.structure(struct_name)
                 for field_input in struct_input.fields:
+                    validators = None
+                    if field_input.validators is not None:
+                        validators = [
+                            RegexValidator(
+                                pattern=v.pattern,
+                                mode=v.mode,
+                                exclude=v.exclude,
+                                flags=re.IGNORECASE if v.ignore_case else 0,
+                            )
+                            for v in field_input.validators
+                        ]
                     builder.field(
                         name=field_input.name,
                         dtype=field_input.dtype,
                         choices=field_input.choices,
-                        description=field_input.description
+                        description=field_input.description,
+                        threshold=field_input.threshold,
+                        validators=validators,
                     )
                 builder._auto_finish()
 
@@ -318,7 +344,8 @@ class Schema:
                 schema.classification(
                     task=cls_input.task,
                     labels=cls_input.labels,
-                    multi_label=cls_input.multi_label
+                    multi_label=cls_input.multi_label,
+                    cls_threshold=cls_input.cls_threshold,
                 )
 
         if validated.relations is not None:
@@ -402,6 +429,16 @@ class Schema:
                         if desc:
                             field_def["description"] = desc
 
+                        threshold = metadata.get("threshold")
+                        if threshold is not None:
+                            field_def["threshold"] = threshold
+
+                        validators = metadata.get("validators")
+                        if validators:
+                            field_def["validators"] = [
+                                _validator_to_dict(v) for v in validators
+                            ]
+
                         fields.append(field_def)
 
                     result["structures"][struct_name] = {"fields": fields}
@@ -415,6 +452,9 @@ class Schema:
                 }
                 if cls_config.get("multi_label", False):
                     cls_def["multi_label"] = True
+                cls_threshold = cls_config.get("cls_threshold", 0.5)
+                if cls_threshold != 0.5:
+                    cls_def["cls_threshold"] = cls_threshold
                 result["classifications"].append(cls_def)
 
         if self.schema["relations"]:

--- a/gliner2/inference/schema_model.py
+++ b/gliner2/inference/schema_model.py
@@ -5,8 +5,34 @@ This module provides validation models for creating GLiNER2 schemas
 from JSON or dictionary inputs.
 """
 
+import re
 from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class ValidatorInput(BaseModel):
+    """Validates a regex span-filter definition (JSON form of RegexValidator).
+
+    Args:
+        pattern: Regular expression to match against an extracted span
+        mode: 'full' requires the whole span to match; 'partial' matches a substring
+        exclude: If True, keep spans that do NOT match (invert the filter)
+        ignore_case: Case-insensitive matching (maps to re.IGNORECASE)
+    """
+    pattern: str = Field(..., min_length=1, description="Regular expression")
+    mode: Literal["full", "partial"] = Field(default="full", description="Match mode")
+    exclude: bool = Field(default=False, description="Invert the filter")
+    ignore_case: bool = Field(default=True, description="Case-insensitive matching")
+
+    @field_validator('pattern')
+    @classmethod
+    def validate_pattern(cls, v: str) -> str:
+        """Ensure the pattern compiles as a regex."""
+        try:
+            re.compile(v)
+        except re.error as err:
+            raise ValueError(f"invalid regex: {v!r}") from err
+        return v
 
 
 class FieldInput(BaseModel):
@@ -17,11 +43,17 @@ class FieldInput(BaseModel):
         dtype: Data type - 'str' for single value, 'list' for multiple values
         choices: Optional list of valid choices for classification-style fields
         description: Optional description of the field
+        threshold: Optional per-field confidence threshold (0..1)
+        validators: Optional regex span filters applied to this field's extractions
     """
     name: str = Field(..., min_length=1, description="Field name")
     dtype: Literal["str", "list"] = Field(default="list", description="Data type")
     choices: Optional[List[str]] = Field(default=None, description="Valid choices")
     description: Optional[str] = Field(default=None, description="Field description")
+    threshold: Optional[float] = Field(default=None, description="Per-field confidence threshold")
+    validators: Optional[List[ValidatorInput]] = Field(
+        default=None, description="Regex span filters"
+    )
 
     @field_validator('choices')
     @classmethod
@@ -29,6 +61,14 @@ class FieldInput(BaseModel):
         """Ensure choices list is not empty if provided."""
         if v is not None and len(v) == 0:
             raise ValueError("choices must contain at least one option")
+        return v
+
+    @field_validator('threshold')
+    @classmethod
+    def validate_threshold(cls, v: Optional[float]) -> Optional[float]:
+        """Ensure threshold is in [0, 1] if provided."""
+        if v is not None and not 0 <= v <= 1:
+            raise ValueError(f"threshold must be between 0 and 1, got {v}")
         return v
 
 
@@ -48,10 +88,12 @@ class ClassificationInput(BaseModel):
         task: Task name
         labels: List of classification labels
         multi_label: Whether multiple labels can be selected
+        cls_threshold: Confidence threshold for this task (0..1)
     """
     task: str = Field(..., min_length=1, description="Task name")
     labels: List[str] = Field(..., min_length=2, description="Classification labels")
     multi_label: bool = Field(default=False, description="Multi-label classification")
+    cls_threshold: float = Field(default=0.5, description="Per-task confidence threshold")
 
     @field_validator('labels')
     @classmethod
@@ -61,6 +103,14 @@ class ClassificationInput(BaseModel):
             raise ValueError("labels must be unique")
         if any(not label.strip() for label in v):
             raise ValueError("labels cannot be empty strings")
+        return v
+
+    @field_validator('cls_threshold')
+    @classmethod
+    def validate_cls_threshold(cls, v: float) -> float:
+        """Ensure cls_threshold is in [0, 1]."""
+        if not 0 <= v <= 1:
+            raise ValueError(f"cls_threshold must be between 0 and 1, got {v}")
         return v
 
 

--- a/tests/test_schema_input_thresholds_validators.py
+++ b/tests/test_schema_input_thresholds_validators.py
@@ -1,0 +1,109 @@
+"""JSON schema (from_dict/to_dict) support for per-field thresholds and regex
+validators, and per-task classification thresholds.
+
+These exercise only the torch-free schema layer (``gliner2.inference.schema`` /
+``schema_model``), so they need no model download.
+"""
+
+import pytest
+
+from gliner2.inference.schema import RegexValidator, Schema
+
+
+def test_from_dict_wires_field_threshold_and_validators():
+    schema = Schema.from_dict(
+        {
+            "structures": {
+                "job": {
+                    "fields": [
+                        {"name": "title", "dtype": "str", "threshold": 0.7},
+                        {
+                            "name": "email",
+                            "dtype": "str",
+                            "validators": [
+                                {"pattern": r"[^@]+@[^@]+", "mode": "partial", "ignore_case": False}
+                            ],
+                        },
+                    ]
+                }
+            }
+        }
+    )
+
+    assert schema._field_metadata["job.title"]["threshold"] == 0.7
+
+    validators = schema._field_metadata["job.email"]["validators"]
+    assert len(validators) == 1
+    v = validators[0]
+    assert isinstance(v, RegexValidator)
+    assert v.mode == "partial"
+    assert v.exclude is False
+    assert v.flags == 0  # ignore_case=False
+    assert v.validate("a@b.com") is True
+    assert v.validate("nope") is False
+
+
+def test_from_dict_wires_cls_threshold():
+    schema = Schema.from_dict(
+        {"classifications": [{"task": "remote", "labels": ["yes", "no"], "cls_threshold": 0.8}]}
+    )
+    cfg = schema.schema["classifications"][0]
+    assert cfg["cls_threshold"] == 0.8
+
+
+def test_to_dict_round_trips_thresholds_and_validators():
+    data = {
+        "structures": {
+            "job": {
+                "fields": [
+                    {"name": "title", "dtype": "str", "threshold": 0.7},
+                    {
+                        "name": "email",
+                        "validators": [
+                            {"pattern": r"[^@]+@[^@]+", "mode": "partial", "exclude": False, "ignore_case": False}
+                        ],
+                    },
+                ]
+            }
+        },
+        "classifications": [{"task": "remote", "labels": ["yes", "no"], "cls_threshold": 0.8}],
+    }
+    out = Schema.from_dict(data).to_dict()
+
+    fields = {f["name"]: f for f in out["structures"]["job"]["fields"]}
+    assert fields["title"]["threshold"] == 0.7
+    assert fields["email"]["validators"] == [
+        {"pattern": r"[^@]+@[^@]+", "mode": "partial", "exclude": False, "ignore_case": False}
+    ]
+    assert out["classifications"][0]["cls_threshold"] == 0.8
+
+    # Idempotent: re-parsing the emitted dict yields the same dict.
+    assert Schema.from_dict(out).to_dict() == out
+
+
+def test_defaults_omitted_from_to_dict():
+    out = Schema.from_dict(
+        {
+            "structures": {"x": {"fields": [{"name": "f"}]}},
+            "classifications": [{"task": "t", "labels": ["a", "b"]}],
+        }
+    ).to_dict()
+    field = out["structures"]["x"]["fields"][0]
+    assert "threshold" not in field
+    assert "validators" not in field
+    assert "cls_threshold" not in out["classifications"][0]
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"structures": {"x": {"fields": [{"name": "f", "threshold": 1.5}]}}},
+        {"structures": {"x": {"fields": [{"name": "f", "validators": [{"pattern": "("}]}]}}},
+        {"classifications": [{"task": "t", "labels": ["a", "b"], "cls_threshold": 2}]},
+    ],
+)
+def test_invalid_inputs_rejected(bad):
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        Schema.from_dict(bad)


### PR DESCRIPTION
## Motivation

`Schema.from_dict` / `from_json` are the way to build a schema from JSON (e.g. when GLiNER2 is served behind an HTTP API and clients send a `SchemaInput` payload). But the JSON format is missing three things the **Python builder already supports**, so they're unreachable from JSON:

- `StructureBuilder.field(..., threshold=…)` — per-field confidence threshold
- `StructureBuilder.field(..., validators=[RegexValidator(...)])` — per-field regex span filters
- `Schema.classification(..., cls_threshold=…)` — per-task classification threshold

`FieldInput` only modeled `name/dtype/choices/description` and `ClassificationInput` only `task/labels/multi_label`, so `from_dict` silently dropped these capabilities.

## Change

Wire the existing builder features through the JSON boundary:

- **`schema_model.py`**: new `ValidatorInput` model (`pattern`, `mode`, `exclude`, `ignore_case`) — a clean JSON mirror of `RegexValidator` that avoids exposing raw `re` flag ints. Add `threshold` + `validators` to `FieldInput` and `cls_threshold` to `ClassificationInput`, with range/regex validation.
- **`from_dict`**: pass `threshold`/`validators` into `builder.field(...)` (converting `ValidatorInput` → `RegexValidator`, `ignore_case` → `re.IGNORECASE`) and `cls_threshold` into `classification(...)`.
- **`to_dict`**: emit the same keys (defaults omitted) so the dict round-trips through `from_dict`.
- Export `ValidatorInput` from the package; add torch-free tests.

## Example

```json
{
  "structures": {
    "contact": {
      "fields": [
        {"name": "name", "dtype": "str", "threshold": 0.7},
        {"name": "email", "dtype": "str",
         "validators": [{"pattern": "[^@]+@[^@]+", "mode": "partial", "ignore_case": false}]}
      ]
    }
  },
  "classifications": [
    {"task": "sentiment", "labels": ["positive", "negative"], "cls_threshold": 0.8}
  ]
}
```

## Backward compatibility

All new fields are optional and default to the builders' existing defaults; `to_dict` omits them when unset, so existing schemas serialize byte-for-byte as before. `from_dict(to_dict(schema))` is idempotent (covered by a test).

## Tests

Added `tests/test_schema_input_thresholds_validators.py` (torch-free — no model download): from_dict wiring, to_dict round-trip/idempotency, defaults-omitted, and rejection of out-of-range thresholds / invalid regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)