### PR TITLE
add boundary architecture #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ result = model.extract_entities("Apple released iPhone 15.", ["company", "produc
 
 `GLiNER2` remains fully backward compatible (`GLiNER2 = SpanExtractor` subclass).
 The boundary architecture is **experimental** and supports entities,
-classification, and optional structured record/event decoding. Record decoding
-must be enabled when creating the boundary checkpoint. See the full guide —
-loading, creating/training a boundary model, record decoding, save/load, LoRA
-aliases, and export mode — in
+classification, optional structured record/event decoding, and optional sparse
+relation extraction. Records and relations must be enabled when creating the
+boundary checkpoint. See the full guide — loading, creating/training a boundary
+model, record and relation decoding, save/load, LoRA aliases, and export mode — in
 [`docs/boundary_architecture.md`](docs/boundary_architecture.md).
 
 ## 📦 Available Models

--- a/gliner2/configuration.py
+++ b/gliner2/configuration.py
@@ -64,6 +64,13 @@ class BoundaryHeadSettings:
     record_anchor_threshold: float = 0.5    # final anchor selection threshold
     record_field_threshold: float = 0.5     # list-field / null decision cutoff
     record_loss_weight: float = 1.0
+    # Sparse typed relation scorer. Disabled by default so boundary checkpoints
+    # without this head retain their existing state-dict shape.
+    enable_relations: bool = False
+    relation_heads_per_type: int = 32
+    relation_tails_per_type: int = 32
+    relation_pair_cap: int = 128
+    relation_loss_weight: float = 1.0
 
 
 # =============================================================================
@@ -152,6 +159,19 @@ def validate_boundary_head(values: Mapping[str, Any]) -> dict:
         "record_loss_weight": float(
             values.get("record_loss_weight", d.record_loss_weight)
         ),
+        "enable_relations": bool(values.get("enable_relations", d.enable_relations)),
+        "relation_heads_per_type": int(
+            values.get("relation_heads_per_type", d.relation_heads_per_type)
+        ),
+        "relation_tails_per_type": int(
+            values.get("relation_tails_per_type", d.relation_tails_per_type)
+        ),
+        "relation_pair_cap": int(
+            values.get("relation_pair_cap", d.relation_pair_cap)
+        ),
+        "relation_loss_weight": float(
+            values.get("relation_loss_weight", d.relation_loss_weight)
+        ),
     }
     if result["export_mode"] not in ("streaming", "vectorized"):
         raise ValueError(
@@ -181,6 +201,14 @@ def validate_boundary_head(values: Mapping[str, Any]) -> dict:
             "boundary_head.record_anchor_proposal_threshold "
             f"({result['record_anchor_proposal_threshold']}) must be <= "
             f"record_anchor_threshold ({result['record_anchor_threshold']})"
+        )
+    for key in ("relation_heads_per_type", "relation_tails_per_type", "relation_pair_cap"):
+        if result[key] <= 0:
+            raise ValueError(f"boundary_head.{key} must be > 0, got {result[key]}")
+    if result["relation_loss_weight"] < 0:
+        raise ValueError(
+            "boundary_head.relation_loss_weight must be >= 0, got "
+            f"{result['relation_loss_weight']}"
         )
 
     positive_keys = [

--- a/gliner2/joint_ie/candidate_scores.py
+++ b/gliner2/joint_ie/candidate_scores.py
@@ -1,0 +1,178 @@
+"""Architecture-neutral sparse candidate score format for joint IE.
+
+The span architecture produces a dense width-oriented :class:`ScoreLattice`;
+the boundary architecture produces sparse candidates directly. Both are mapped
+onto :class:`CandidateScoreSet` — a flat list of mention scores plus optional
+relation-role scores — which then feeds the *unchanged* ``NodeCandidate`` /
+``EdgeCandidate`` / ``JointProblem`` optimizer contract. Coordinates are
+half-open ``[start, end)`` token offsets throughout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Hashable, List, Mapping, Optional, Sequence, Tuple
+
+from gliner2.joint_ie.candidates import (
+    EdgeCandidate,
+    JointProblem,
+    NodeCandidate,
+    center_logit,
+    sigmoid,
+)
+
+
+@dataclass(frozen=True)
+class MentionScore:
+    """One scored span mention (half-open ``[start, end)`` token offsets)."""
+
+    query_id: int
+    entity_type: str
+    start: int
+    end: int
+    logit: float
+    probability: float
+
+    @property
+    def key(self) -> Tuple[str, int, int]:
+        return (self.entity_type, self.start, self.end)
+
+
+@dataclass(frozen=True)
+class RelationRoleScore:
+    """A mention's compatibility with one role of one relation type."""
+
+    relation_type: str
+    role: str  # "head" | "tail"
+    mention_id: Hashable
+    logit: float
+    probability: float
+
+
+@dataclass
+class CandidateScoreSet:
+    """Sparse, architecture-neutral candidate scores for one text."""
+
+    text: str
+    mentions: Tuple[MentionScore, ...]
+    relation_roles: Tuple[RelationRoleScore, ...] = ()
+    classifications: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+def score_lattice_to_candidate_score_set(lattice: Any) -> CandidateScoreSet:
+    """Convert a dense span :class:`ScoreLattice` into a sparse score set.
+
+    Reads the entity task's single count hypothesis (``role_logits[0]`` shaped
+    ``[num_types, L, W]``) and emits one :class:`MentionScore` per valid,
+    above-floor span cell, mapping inclusive width cells to half-open spans.
+    """
+    span_starts = lattice.span_starts
+    span_ends = lattice.span_ends
+    valid = lattice.valid_span_mask
+
+    mentions: List[MentionScore] = []
+    query_id = 0
+    for task in lattice.tasks:
+        if task.task_type != "entities" or not task.count_hypotheses:
+            continue
+        hyp = task.count_hypotheses[0]
+        role_logits = hyp.role_logits[0]           # [num_types, L, W]
+        role_probs = hyp.role_probabilities[0]
+        num_types = role_logits.shape[0]
+        for t in range(num_types):
+            entity_type = task.roles[t] if t < len(task.roles) else str(t)
+            length = role_logits.shape[1]
+            width = role_logits.shape[2]
+            for i in range(length):
+                for w in range(width):
+                    if not bool(valid[i, w]):
+                        continue
+                    prob = float(role_probs[t, i, w])
+                    start = int(span_starts[i, w])
+                    end = int(span_ends[i, w]) + 1  # inclusive -> half-open
+                    mentions.append(
+                        MentionScore(
+                            query_id=query_id,
+                            entity_type=entity_type,
+                            start=start,
+                            end=end,
+                            logit=float(role_logits[t, i, w]),
+                            probability=prob,
+                        )
+                    )
+            query_id += 1
+
+    return CandidateScoreSet(text=lattice.text, mentions=tuple(mentions))
+
+
+@dataclass(frozen=True)
+class ScoredRelationEdge:
+    """A scored (head, tail) relation proposal referencing mention keys."""
+
+    relation_type: str
+    head: Hashable
+    tail: Hashable
+    logit: float
+    probability: float
+
+
+def candidate_score_set_to_problem(
+    score_set: CandidateScoreSet,
+    edges: Sequence[ScoredRelationEdge] = (),
+    *,
+    mention_threshold: float = 0.5,
+    constraints: Sequence[Any] = (),
+    decision_threshold: float = 0.5,
+) -> JointProblem:
+    """Build a :class:`JointProblem` from sparse mention + edge scores.
+
+    Node/edge utilities are centered log-odds (positive => above threshold), so
+    the existing greedy/beam optimizers and constraints work unchanged.
+    """
+    nodes: List[NodeCandidate] = []
+    keep_ids = set()
+    for m in score_set.mentions:
+        if m.probability < mention_threshold:
+            continue
+        node = NodeCandidate(
+            entity_type=m.entity_type,
+            start=m.start,
+            end=m.end,
+            score=center_logit(m.logit, decision_threshold),
+            probability=m.probability,
+            candidate_id=m.key,
+        )
+        nodes.append(node)
+        keep_ids.add(m.key)
+
+    edge_cands: List[EdgeCandidate] = []
+    for e in edges:
+        if e.head not in keep_ids or e.tail not in keep_ids:
+            continue
+        edge_cands.append(
+            EdgeCandidate(
+                relation_type=e.relation_type,
+                head=e.head,
+                tail=e.tail,
+                score=center_logit(e.logit, decision_threshold),
+                head_probability=e.probability,
+                tail_probability=e.probability,
+            )
+        )
+
+    return JointProblem(
+        nodes=tuple(nodes),
+        edges=tuple(edge_cands),
+        constraints=tuple(constraints),
+    )
+
+
+__all__ = [
+    "MentionScore",
+    "RelationRoleScore",
+    "CandidateScoreSet",
+    "ScoredRelationEdge",
+    "score_lattice_to_candidate_score_set",
+    "candidate_score_set_to_problem",
+]

--- a/gliner2/models/boundary/__init__.py
+++ b/gliner2/models/boundary/__init__.py
@@ -49,6 +49,13 @@ from gliner2.models.boundary.record_decode import (
     decode_group,
     derive_count,
 )
+from gliner2.models.boundary.relations import (
+    RelationPairBatch,
+    RelationProposalSettings,
+    RelationTypeSpec,
+    SparseRelationScorer,
+    TypedRelationPairGenerator,
+)
 
 __all__ = [
     "BoundaryEncoding",
@@ -84,4 +91,9 @@ __all__ = [
     "DecodedRecord",
     "decode_group",
     "derive_count",
+    "RelationPairBatch",
+    "RelationProposalSettings",
+    "RelationTypeSpec",
+    "SparseRelationScorer",
+    "TypedRelationPairGenerator",
 ]

--- a/gliner2/models/boundary/engine.py
+++ b/gliner2/models/boundary/engine.py
@@ -10,6 +10,7 @@ import torch
 from gliner2.inference.candidate_decoder import token_boundaries_to_character_offsets
 from gliner2.inference.runtime import ExtractorRuntimeMixin
 from gliner2.models.boundary.model import BoundaryExtractorModel
+from gliner2.models.base import QueryLayout
 from gliner2.models.boundary.record_decode import decode_group
 
 
@@ -31,7 +32,7 @@ class BoundaryExtractor(ExtractorRuntimeMixin, BoundaryExtractorModel):
     Overrides ``_extract_from_batch`` with the sparse candidate path: encode →
     boundary head → threshold + flat-span resolution → exact half-open
     token→character conversion. Entities, classification, and enabled
-    record/event schemas are supported; sparse relation decoding is deferred.
+    record/event schemas and enabled sparse relation decoding are supported.
     """
 
     architecture = "boundary"
@@ -74,6 +75,12 @@ class BoundaryExtractor(ExtractorRuntimeMixin, BoundaryExtractorModel):
             for name, instances in record_results.items():
                 if instances:
                     sample[name] = instances
+
+            relation_results = self._decode_relations(
+                i, core, candidates, metadata_list[i], threshold, offset,
+                start_map, end_map, text, text_len, include_confidence, include_spans,
+            )
+            sample.update(relation_results)
 
             entity_results: "OrderedDict[str, Any]" = OrderedDict()
             for qid, spec in enumerate(specs):
@@ -121,6 +128,86 @@ class BoundaryExtractor(ExtractorRuntimeMixin, BoundaryExtractorModel):
             results.append(sample)
 
         return results
+
+    def _decode_relations(
+        self,
+        sample_index: int,
+        core: Dict[str, Any],
+        candidates,
+        metadata: Dict[str, Any],
+        threshold: float,
+        offset: int,
+        start_map,
+        end_map,
+        text: str,
+        text_len: int,
+        include_confidence: bool,
+        include_spans: bool,
+    ) -> Dict[str, Any]:
+        """Decode sparse relation pairs for one sample."""
+        if not getattr(self, "enable_relations", False) or candidates is None:
+            return {}
+        rel_specs = core["rel_specs"][sample_index]
+        if not rel_specs:
+            return {}
+        sample_candidates = self._single_sample_candidates(candidates, sample_index)
+        pairs = self.relation_pair_generator.generate(
+            sample_candidates,
+            [QueryLayout(queries=())],
+            [entry["spec"] for entry in rel_specs],
+        )
+        if not len(pairs):
+            return {}
+        query_states = torch.stack(
+            [entry["query_state"] for entry in rel_specs]
+        ).unsqueeze(0)
+        logits = self.relation_scorer(
+            core["text_states"][sample_index:sample_index + 1],
+            query_states,
+            sample_candidates,
+            pairs,
+        )
+        probabilities = torch.sigmoid(logits)
+        out: Dict[str, Any] = {}
+        relation_metadata = metadata.get("relation_metadata", {})
+        for pair_index, probability in enumerate(probabilities):
+            relation_type = pairs.relation_types[pair_index]
+            relation_threshold = relation_metadata.get(relation_type, {}).get(
+                "threshold", threshold
+            )
+            if relation_threshold is None:
+                relation_threshold = threshold
+            score = float(probability.detach())
+            if score < relation_threshold:
+                continue
+            hs = int(pairs.head_start[pair_index]) - offset
+            he = int(pairs.head_end[pair_index]) - offset
+            ts = int(pairs.tail_start[pair_index]) - offset
+            te = int(pairs.tail_end[pair_index]) - offset
+            if not (0 <= hs < he <= text_len and 0 <= ts < te <= text_len):
+                continue
+            h0, h1 = token_boundaries_to_character_offsets(hs, he, start_map, end_map)
+            t0, t1 = token_boundaries_to_character_offsets(ts, te, start_map, end_map)
+            head, tail = text[h0:h1].strip(), text[t0:t1].strip()
+            if not head or not tail:
+                continue
+            if include_spans:
+                value = {
+                    "head": {"text": head, "start": h0, "end": h1},
+                    "tail": {"text": tail, "start": t0, "end": t1},
+                }
+                if include_confidence:
+                    value["head"]["confidence"] = score
+                    value["tail"]["confidence"] = score
+            elif include_confidence:
+                value = {
+                    "head": {"text": head, "confidence": score},
+                    "tail": {"text": tail, "confidence": score},
+                }
+            else:
+                value = (head, tail)
+            out.setdefault(relation_type, []).append(value)
+        return out
 
     def _decode_records(
         self,

--- a/gliner2/models/boundary/model.py
+++ b/gliner2/models/boundary/model.py
@@ -40,6 +40,12 @@ from gliner2.models.boundary.proposal import (
     SparseBoundaryProposer,
 )
 from gliner2.models.boundary.scoring import SparseBoundaryPairScorer, gather_boundary_states
+from gliner2.models.boundary.relations import (
+    RelationProposalSettings,
+    RelationTypeSpec,
+    SparseRelationScorer,
+    TypedRelationPairGenerator,
+)
 from gliner2.models.base import QueryLayout, QuerySpec
 from gliner2.models.outputs import CandidateTensorBatch, ExtractorOutput
 from gliner2.processing.targets import (
@@ -328,9 +334,12 @@ class BoundaryExtractorModel(BaseExtractorModel):
 
     def task_module_names(self) -> Tuple[str, ...]:
         base = ("classifier", "boundary_head")
+        extras = ()
         if getattr(self, "enable_records", False):
-            return base + ("record_decoder",)
-        return base
+            extras += ("record_decoder",)
+        if getattr(self, "enable_relations", False):
+            extras += ("relation_scorer",)
+        return base + extras
 
     def __init__(self, config: ExtractorConfig, encoder_config=None, tokenizer=None):
         super().__init__(config)
@@ -363,6 +372,7 @@ class BoundaryExtractorModel(BaseExtractorModel):
         settings = BoundaryHeadSettings(**config.boundary_head)
         self.boundary_settings = settings
         self.enable_records = settings.enable_records
+        self.enable_relations = settings.enable_relations
         self.boundary_head = BoundaryHead(
             self.hidden_size, settings, query_dim=self.hidden_size,
             build_candidate_states=settings.enable_records,
@@ -373,6 +383,17 @@ class BoundaryExtractorModel(BaseExtractorModel):
                 self.hidden_size,
                 settings.record_dim,
                 settings.record_instance_queries,
+            )
+        if self.enable_relations:
+            self.relation_pair_generator = TypedRelationPairGenerator(
+                RelationProposalSettings(
+                    heads_per_relation=settings.relation_heads_per_type,
+                    tails_per_relation=settings.relation_tails_per_type,
+                    pair_cap=settings.relation_pair_cap,
+                )
+            )
+            self.relation_scorer = SparseRelationScorer(
+                self.hidden_size, dropout=settings.dropout
             )
 
         self._lora_layers = {}
@@ -415,12 +436,14 @@ class BoundaryExtractorModel(BaseExtractorModel):
         ext_specs: List[List[Dict[str, Any]]] = []
         ext_embs: List[List[torch.Tensor]] = []
         cls_specs: List[List[Dict[str, Any]]] = []
+        rel_specs: List[List[Dict[str, Any]]] = []
         word_offsets: List[int] = []
 
         for i in range(n):
             specs_i: List[Dict[str, Any]] = []
             embs_i: List[torch.Tensor] = []
             cls_i: List[Dict[str, Any]] = []
+            rel_i: List[Dict[str, Any]] = []
             text_len_i = len(batch.start_mappings[i]) if batch.start_mappings else text_lengths[i]
             word_offsets.append(max(text_lengths[i] - text_len_i, 0))
 
@@ -441,6 +464,7 @@ class BoundaryExtractorModel(BaseExtractorModel):
                             "group_embs": torch.stack(group_embs),
                         })
                     continue
+                first_query_id = len(specs_i)
                 for fidx, fname in enumerate(field_names):
                     if 1 + fidx >= len(group_embs):
                         break
@@ -452,10 +476,29 @@ class BoundaryExtractorModel(BaseExtractorModel):
                         "field_name": fname,
                     })
                     embs_i.append(group_embs[1 + fidx])
+                if task_type == "relations" and len(specs_i) > first_query_id:
+                    query_ids = {
+                        field_names[idx]: first_query_id + idx
+                        for idx in range(min(len(field_names), len(specs_i) - first_query_id))
+                    }
+                    head_id = query_ids.get("head")
+                    tail_id = query_ids.get("tail")
+                    if head_id is not None and tail_id is not None:
+                        rel_i.append({
+                            "group_index": g,
+                            "relation_type": name,
+                            "spec": RelationTypeSpec(
+                                name, head_query_ids=(head_id,), tail_query_ids=(tail_id,)
+                            ),
+                            "query_state": torch.stack(
+                                group_embs[1:1 + len(field_names)]
+                            ).mean(dim=0),
+                        })
 
             ext_specs.append(specs_i)
             ext_embs.append(embs_i)
             cls_specs.append(cls_i)
+            rel_specs.append(rel_i)
 
         max_q = max((len(e) for e in ext_embs), default=0)
         query_states = torch.zeros(n, max_q, h, device=device, dtype=token_embeddings.dtype)
@@ -473,6 +516,7 @@ class BoundaryExtractorModel(BaseExtractorModel):
             "query_mask": query_mask,
             "ext_specs": ext_specs,
             "cls_specs": cls_specs,
+            "rel_specs": rel_specs,
             "word_offsets": word_offsets,
         }
 
@@ -556,6 +600,102 @@ class BoundaryExtractorModel(BaseExtractorModel):
                 )
         return total
 
+    @staticmethod
+    def _single_sample_candidates(
+        candidates: CandidateTensorBatch, sample_index: int
+    ) -> CandidateTensorBatch:
+        """Keep one sample while preserving the padded candidate contract."""
+        return CandidateTensorBatch(
+            indices=candidates.indices[sample_index:sample_index + 1],
+            proposal_logits=candidates.proposal_logits[sample_index:sample_index + 1],
+            pair_logits=candidates.pair_logits[sample_index:sample_index + 1],
+            valid_mask=candidates.valid_mask[sample_index:sample_index + 1],
+            query_mask=candidates.query_mask[sample_index:sample_index + 1],
+            candidate_states=(
+                candidates.candidate_states[sample_index:sample_index + 1]
+                if candidates.candidate_states is not None else None
+            ),
+        )
+
+    def _relation_loss(self, batch, core, candidates) -> Optional[torch.Tensor]:
+        """Binary relation-pair loss over sparse, gold-inclusive proposals."""
+        if candidates is None:
+            return None
+        structure_labels = getattr(batch, "structure_labels", None)
+        if not structure_labels:
+            return None
+
+        total = torch.zeros((), device=core["text_states"].device)
+        groups = 0
+        empty_layout = QueryLayout(queries=())
+        for sample_index, rel_specs in enumerate(core["rel_specs"]):
+            if not rel_specs:
+                continue
+            sample_candidates = self._single_sample_candidates(candidates, sample_index)
+            relation_schema = [entry["spec"] for entry in rel_specs]
+            pairs = self.relation_pair_generator.generate(
+                sample_candidates, [empty_layout], relation_schema
+            )
+            if len(pairs) == 0:
+                continue
+            query_states = torch.stack(
+                [entry["query_state"] for entry in rel_specs]
+            ).unsqueeze(0)
+            logits = self.relation_scorer(
+                core["text_states"][sample_index:sample_index + 1],
+                query_states,
+                sample_candidates,
+                pairs,
+            )
+            gold = set()
+            for relation_index, entry in enumerate(rel_specs):
+                labels = structure_labels[sample_index][entry["group_index"]]
+                if not labels or labels[0] == 0:
+                    continue
+                specs = core["ext_specs"][sample_index]
+                head_spec = specs[entry["spec"].head_query_ids[0]]
+                tail_spec = specs[entry["spec"].tail_query_ids[0]]
+                for instance in labels[1]:
+                    if (
+                        head_spec["field_index"] >= len(instance)
+                        or tail_spec["field_index"] >= len(instance)
+                    ):
+                        continue
+                    for hs, he in _iter_inclusive_spans(
+                        instance[head_spec["field_index"]]
+                    ):
+                        for ts, te in _iter_inclusive_spans(
+                            instance[tail_spec["field_index"]]
+                        ):
+                            gold.add((relation_index, hs, he + 1, ts, te + 1))
+            labels = torch.tensor(
+                [
+                    float(
+                        (
+                            int(relation_index),
+                            int(hs),
+                            int(he),
+                            int(ts),
+                            int(te),
+                        ) in gold
+                    )
+                    for relation_index, hs, he, ts, te in zip(
+                        pairs.relation_index,
+                        pairs.head_start,
+                        pairs.head_end,
+                        pairs.tail_start,
+                        pairs.tail_end,
+                    )
+                ],
+                device=logits.device,
+                dtype=logits.dtype,
+            )
+            total = total + F.binary_cross_entropy_with_logits(logits, labels)
+            groups += 1
+        if groups == 0:
+            return None
+        return self.boundary_settings.relation_loss_weight * total / groups
+
     # =========================================================================
     # Forward
     # =========================================================================
@@ -602,15 +742,23 @@ class BoundaryExtractorModel(BaseExtractorModel):
             and output.candidates.candidate_states is not None
         ):
             record_loss = self._record_loss(batch, core, output.candidates, targets)
+        relation_loss = None
+        if self.enable_relations and self.training and output.candidates is not None:
+            relation_loss = self._relation_loss(batch, core, output.candidates)
 
         needs_combine = (
-            targets is not None or bool(cls_loss.detach()) or record_loss is not None
+            targets is not None
+            or bool(cls_loss.detach())
+            or record_loss is not None
+            or relation_loss is not None
         )
         if needs_combine:
             span_total = output.total_loss if output.total_loss is not None else torch.zeros((), device=cls_loss.device)
             combined = span_total + cls_loss
             if record_loss is not None:
                 combined = combined + record_loss["total"]
+            if relation_loss is not None:
+                combined = combined + relation_loss
             output.total_loss = combined
             output.loss = combined
             if output.losses is not None:
@@ -618,6 +766,8 @@ class BoundaryExtractorModel(BaseExtractorModel):
                 if record_loss is not None:
                     output.losses["record_object_loss"] = record_loss["object"]
                     output.losses["record_field_loss"] = record_loss["field"]
+                if relation_loss is not None:
+                    output.losses["relation_loss"] = relation_loss
         return output
 
     def _record_loss(self, batch, core, candidates, targets) -> Dict[str, torch.Tensor]:

--- a/gliner2/models/boundary/relations.py
+++ b/gliner2/models/boundary/relations.py
@@ -1,0 +1,210 @@
+"""Sparse, typed relation extraction for the boundary architecture.
+
+Relations reuse the entity mention candidates rather than introducing a second
+extraction representation. Pair generation is *typed and capped*: for each
+relation type we keep only the top-``Rh`` head-typed and top-``Rt`` tail-typed
+mentions and score their capped cross product. Work is therefore ``O(Rh*Rt)``
+per relation type with fixed caps — never the ``O(N^2)`` all-pairs matrix.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Sequence, Tuple
+
+import torch
+import torch.nn as nn
+
+from gliner2.models.base import QueryLayout
+from gliner2.models.outputs import CandidateTensorBatch
+
+
+@dataclass(frozen=True)
+class RelationProposalSettings:
+    heads_per_relation: int = 32
+    tails_per_relation: int = 32
+    pair_cap: int = 128
+
+
+@dataclass(frozen=True)
+class RelationTypeSpec:
+    """A relation type with its allowed head/tail entity queries."""
+
+    relation_type: str
+    head_query_ids: Tuple[int, ...]
+    tail_query_ids: Tuple[int, ...]
+    allow_self: bool = False
+
+
+@dataclass
+class RelationPairBatch:
+    """Flattened typed relation-pair proposals across a batch.
+
+    All index tensors have shape ``[P]`` (P = total proposed pairs). ``*_end``
+    are half-open (last covered token is ``end - 1``).
+    """
+
+    batch_index: torch.LongTensor
+    relation_index: torch.LongTensor
+    head_start: torch.LongTensor
+    head_end: torch.LongTensor
+    tail_start: torch.LongTensor
+    tail_end: torch.LongTensor
+    head_prob: torch.Tensor
+    tail_prob: torch.Tensor
+    head_keys: List[Tuple[str, int, int]] = field(default_factory=list)
+    tail_keys: List[Tuple[str, int, int]] = field(default_factory=list)
+    relation_types: List[str] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return int(self.batch_index.shape[0])
+
+
+def _query_type(layout: QueryLayout, query_id: int) -> str:
+    try:
+        return layout.query(query_id).role_name
+    except KeyError:
+        return str(query_id)
+
+
+def _top_mentions(
+    candidates: CandidateTensorBatch,
+    b: int,
+    query_ids: Sequence[int],
+    top_k: int,
+) -> List[Tuple[float, int, int, int]]:
+    """Return up to ``top_k`` (prob, start, end, query_id) for the given queries."""
+    scored: List[Tuple[float, int, int, int]] = []
+    probs = torch.sigmoid(candidates.pair_logits)
+    c = candidates.indices.shape[2]
+    for qid in query_ids:
+        if qid >= candidates.query_mask.shape[1] or not bool(candidates.query_mask[b, qid]):
+            continue
+        for ci in range(c):
+            if not bool(candidates.valid_mask[b, qid, ci]):
+                continue
+            p = float(probs[b, qid, ci].detach())
+            s = int(candidates.indices[b, qid, ci, 0])
+            e = int(candidates.indices[b, qid, ci, 1])
+            scored.append((p, s, e, qid))
+    scored.sort(key=lambda t: (-t[0], t[1], t[2]))
+    return scored[:top_k]
+
+
+class TypedRelationPairGenerator:
+    """Generate typed, capped relation pairs from entity candidates."""
+
+    def __init__(self, settings: RelationProposalSettings | None = None) -> None:
+        self.settings = settings or RelationProposalSettings()
+
+    def generate(
+        self,
+        candidates: CandidateTensorBatch,
+        query_layouts: Sequence[QueryLayout],
+        relation_schema: Sequence[RelationTypeSpec],
+    ) -> RelationPairBatch:
+        s = self.settings
+        bi: List[int] = []
+        ri: List[int] = []
+        hs: List[int] = []
+        he: List[int] = []
+        ts: List[int] = []
+        te: List[int] = []
+        hp: List[float] = []
+        tp: List[float] = []
+        hkeys: List[Tuple[str, int, int]] = []
+        tkeys: List[Tuple[str, int, int]] = []
+        rtypes: List[str] = []
+
+        batch_size = candidates.indices.shape[0]
+        for b in range(batch_size):
+            layout = query_layouts[b] if b < len(query_layouts) else None
+            for r_index, spec in enumerate(relation_schema):
+                heads = _top_mentions(candidates, b, spec.head_query_ids, s.heads_per_relation)
+                tails = _top_mentions(candidates, b, spec.tail_query_ids, s.tails_per_relation)
+                pairs: List[Tuple[float, tuple, tuple]] = []
+                for (hprob, h0, h1, hq) in heads:
+                    for (tprob, t0, t1, tq) in tails:
+                        if not spec.allow_self and (h0, h1) == (t0, t1):
+                            continue
+                        pairs.append((hprob * tprob, (hprob, h0, h1, hq), (tprob, t0, t1, tq)))
+                pairs.sort(key=lambda t: -t[0])
+                for _, (hprob, h0, h1, hq), (tprob, t0, t1, tq) in pairs[: s.pair_cap]:
+                    bi.append(b)
+                    ri.append(r_index)
+                    hs.append(h0); he.append(h1); ts.append(t0); te.append(t1)
+                    hp.append(hprob); tp.append(tprob)
+                    htype = _query_type(layout, hq) if layout is not None else str(hq)
+                    ttype = _query_type(layout, tq) if layout is not None else str(tq)
+                    hkeys.append((htype, h0, h1))
+                    tkeys.append((ttype, t0, t1))
+                    rtypes.append(spec.relation_type)
+
+        device = candidates.indices.device
+        long = lambda xs: torch.tensor(xs, dtype=torch.long, device=device)
+        flt = lambda xs: torch.tensor(xs, dtype=torch.float, device=device)
+        return RelationPairBatch(
+            batch_index=long(bi), relation_index=long(ri),
+            head_start=long(hs), head_end=long(he),
+            tail_start=long(ts), tail_end=long(te),
+            head_prob=flt(hp), tail_prob=flt(tp),
+            head_keys=hkeys, tail_keys=tkeys, relation_types=rtypes,
+        )
+
+
+class SparseRelationScorer(nn.Module):
+    """Score proposed relation pairs from boundary endpoint states.
+
+    Uses only local features (four endpoint boundary states, the relation query,
+    relative order and a normalized distance) — no dense pair matrix.
+    """
+
+    def __init__(self, hidden_size: int, dropout: float = 0.0) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        in_dim = 5 * hidden_size + 2
+        self.mlp = nn.Sequential(
+            nn.Linear(in_dim, hidden_size),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden_size, 1),
+        )
+
+    def forward(
+        self,
+        boundary_states: torch.Tensor,          # [B, L, H]
+        relation_query_states: torch.Tensor,    # [B, R, H]
+        entity_candidates: CandidateTensorBatch,  # (unused indices carrier; kept for API)
+        relation_pairs: RelationPairBatch,
+    ) -> torch.Tensor:
+        if len(relation_pairs) == 0:
+            return boundary_states.new_zeros(0)
+
+        b = relation_pairs.batch_index
+        length = boundary_states.shape[1]
+
+        def gather(pos: torch.Tensor) -> torch.Tensor:
+            pos = pos.clamp(0, max(length - 1, 0))
+            return boundary_states[b, pos]
+
+        h_start = gather(relation_pairs.head_start)
+        h_end = gather(relation_pairs.head_end - 1)
+        t_start = gather(relation_pairs.tail_start)
+        t_end = gather(relation_pairs.tail_end - 1)
+        rel = relation_query_states[b, relation_pairs.relation_index]
+
+        delta = (relation_pairs.tail_start - relation_pairs.head_start).float()
+        order = torch.sign(delta).unsqueeze(-1)
+        dist = (delta.abs() / float(max(length, 1))).unsqueeze(-1)
+
+        feats = torch.cat([h_start, h_end, t_start, t_end, rel, order, dist], dim=-1)
+        return self.mlp(feats).squeeze(-1)
+
+
+__all__ = [
+    "RelationProposalSettings",
+    "RelationTypeSpec",
+    "RelationPairBatch",
+    "TypedRelationPairGenerator",
+    "SparseRelationScorer",
+]

--- a/tests/joint_ie/test_candidate_scores.py
+++ b/tests/joint_ie/test_candidate_scores.py
@@ -1,0 +1,80 @@
+"""Sparse CandidateScoreSet + span-lattice bridge + optimizer integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from gliner2.joint_ie.candidate_scores import (
+    CandidateScoreSet,
+    MentionScore,
+    ScoredRelationEdge,
+    candidate_score_set_to_problem,
+    score_lattice_to_candidate_score_set,
+)
+from gliner2.joint_ie.constraints import TypedEndpoints
+from gliner2.joint_ie.optimizers import BeamOptimizer, GreedyOptimizer
+
+
+def _score_set():
+    return CandidateScoreSet(
+        text="Alice works at Acme",
+        mentions=(
+            MentionScore(0, "person", 0, 1, 4.0, 0.98),
+            MentionScore(1, "org", 3, 4, 4.0, 0.98),
+            MentionScore(0, "person", 2, 3, -4.0, 0.02),  # below threshold, dropped
+        ),
+    )
+
+
+def test_candidate_score_set_to_problem_thresholds_and_builds_edges():
+    css = _score_set()
+    edges = [ScoredRelationEdge("works_for", ("person", 0, 1), ("org", 3, 4), 4.0, 0.98)]
+    problem = candidate_score_set_to_problem(css, edges)
+    assert len(problem.nodes) == 2  # low-prob mention filtered
+    assert len(problem.edges) == 1
+    assert problem.edges[0].head == ("person", 0, 1)
+
+
+def test_edge_referencing_dropped_mention_is_pruned():
+    css = _score_set()
+    bad = [ScoredRelationEdge("works_for", ("person", 2, 3), ("org", 3, 4), 4.0, 0.98)]
+    problem = candidate_score_set_to_problem(css, bad)
+    assert len(problem.edges) == 0
+
+
+def test_typed_endpoints_and_optimizers_select_relation():
+    css = _score_set()
+    edges = [ScoredRelationEdge("works_for", ("person", 0, 1), ("org", 3, 4), 4.0, 0.98)]
+    constraints = [TypedEndpoints("works_for", ("person",), ("org",))]
+    problem = candidate_score_set_to_problem(css, edges, constraints=constraints)
+
+    for optimizer in (GreedyOptimizer(), BeamOptimizer(beam_width=8)):
+        solution = optimizer.optimize(problem)
+        assert {e.relation_type for e in solution.edges} == {"works_for"}
+        assert len(solution.nodes) == 2
+
+
+def test_score_lattice_to_candidate_score_set_maps_halfopen_spans():
+    # A minimal ScoreLattice-shaped object: one entity task, L=2, W=2.
+    role_logits = torch.full((1, 2, 2, 2), -5.0)   # [count, types, L, W]
+    role_logits[0, 0, 0, 0] = 5.0                   # type "a", start 0 width 0 -> [0,1)
+    role_probs = torch.sigmoid(role_logits)
+    hyp = SimpleNamespace(role_logits=role_logits, role_probabilities=role_probs)
+    task = SimpleNamespace(
+        task_type="entities", roles=("a", "b"), count_hypotheses=[hyp]
+    )
+    span_starts = torch.tensor([[0, 0], [1, 1]])
+    span_ends = torch.tensor([[0, 1], [1, 1]])       # inclusive ends
+    valid = torch.tensor([[True, True], [True, False]])
+    lattice = SimpleNamespace(
+        text="x y", span_starts=span_starts, span_ends=span_ends,
+        valid_span_mask=valid, tasks=[task],
+    )
+
+    css = score_lattice_to_candidate_score_set(lattice)
+    high = [m for m in css.mentions if m.probability > 0.5]
+    assert len(high) == 1
+    m = high[0]
+    assert (m.entity_type, m.start, m.end) == ("a", 0, 1)  # inclusive 0 -> half-open [0,1)

--- a/tests/models/boundary/test_relations.py
+++ b/tests/models/boundary/test_relations.py
@@ -1,0 +1,187 @@
+"""Sparse typed relation extraction: typed/capped pairing + scorer overfit."""
+
+from __future__ import annotations
+
+import torch
+
+from gliner2.models.base import QueryLayout, QuerySpec
+from gliner2.models.outputs import CandidateTensorBatch
+from gliner2.models.boundary.relations import (
+    RelationProposalSettings,
+    RelationTypeSpec,
+    SparseRelationScorer,
+    TypedRelationPairGenerator,
+)
+
+
+def _layout(role_names):
+    return QueryLayout(
+        queries=tuple(
+            QuerySpec(query_id=i, task_index=0, task_type="entities",
+                      task_name="entities", role_index=i, role_name=name,
+                      field_path=(name,), extractive=True)
+            for i, name in enumerate(role_names)
+        )
+    )
+
+
+def _candidates(spans_per_query, length):
+    """Build a CandidateTensorBatch (B=1) from ``spans_per_query`` = list per query."""
+    q = len(spans_per_query)
+    c = max((len(s) for s in spans_per_query), default=1)
+    indices = torch.zeros(1, q, c, 2, dtype=torch.long)
+    valid = torch.zeros(1, q, c, dtype=torch.bool)
+    pair_logits = torch.full((1, q, c), -10.0)
+    for qi, spans in enumerate(spans_per_query):
+        for ci, (s, e) in enumerate(spans):
+            indices[0, qi, ci, 0] = s
+            indices[0, qi, ci, 1] = e
+            valid[0, qi, ci] = True
+            pair_logits[0, qi, ci] = 5.0
+    return CandidateTensorBatch(
+        indices=indices,
+        proposal_logits=torch.zeros(1, q, c),
+        pair_logits=pair_logits,
+        valid_mask=valid,
+        query_mask=torch.ones(1, q, dtype=torch.bool),
+    )
+
+
+def test_typed_pair_generation_respects_endpoint_types():
+    layout = _layout(["person", "org"])
+    cands = _candidates([[(0, 1), (4, 5)], [(2, 3), (5, 6)]], length=7)
+    spec = RelationTypeSpec("works_for", head_query_ids=(0,), tail_query_ids=(1,))
+    pairs = TypedRelationPairGenerator().generate(cands, [layout], [spec])
+
+    assert len(pairs) == 4  # 2 heads x 2 tails
+    assert all(k[0] == "person" for k in pairs.head_keys)
+    assert all(k[0] == "org" for k in pairs.tail_keys)
+    assert all(rt == "works_for" for rt in pairs.relation_types)
+
+
+def test_pairing_is_capped_and_independent_of_sequence_length():
+    layout = _layout(["person", "org"])
+    # Same small candidate counts regardless of a long sequence -> no N^2 blowup.
+    cands = _candidates([[(0, 1), (4, 5), (8, 9)], [(2, 3), (6, 7)]], length=500)
+    spec = RelationTypeSpec("works_for", (0,), (1,))
+    settings = RelationProposalSettings(heads_per_relation=2, tails_per_relation=2, pair_cap=3)
+    pairs = TypedRelationPairGenerator(settings).generate(cands, [layout], [spec])
+    # top-2 heads x top-2 tails = 4, capped to pair_cap=3.
+    assert len(pairs) == 3
+
+
+def test_no_self_pairs_by_default():
+    layout = _layout(["thing", "thing2"])
+    cands = _candidates([[(0, 1)], [(0, 1)]], length=5)
+    spec = RelationTypeSpec("same", (0,), (1,))
+    pairs = TypedRelationPairGenerator().generate(cands, [layout], [spec])
+    assert len(pairs) == 0  # identical span filtered as a self-pair
+
+
+def test_sparse_relation_scorer_overfits_gold_pairs():
+    torch.manual_seed(0)
+    hidden = 16
+    length = 6
+    boundary_states = torch.randn(1, length, hidden)
+    rel_query = torch.randn(1, 1, hidden)
+
+    layout = _layout(["person", "org"])
+    cands = _candidates([[(0, 1), (4, 5)], [(2, 3), (5, 6)]], length=length)
+    spec = RelationTypeSpec("works_for", (0,), (1,))
+    pairs = TypedRelationPairGenerator().generate(cands, [layout], [spec])
+
+    # Gold: (person 0,1) -> (org 2,3)
+    gold = torch.tensor([
+        1.0 if (int(hs), int(he), int(ts), int(te)) == (0, 1, 2, 3) else 0.0
+        for hs, he, ts, te in zip(pairs.head_start, pairs.head_end, pairs.tail_start, pairs.tail_end)
+    ])
+
+    scorer = SparseRelationScorer(hidden)
+    opt = torch.optim.Adam(scorer.parameters(), lr=1e-2)
+    for _ in range(400):
+        opt.zero_grad()
+        logits = scorer(boundary_states, rel_query, cands, pairs)
+        loss = torch.nn.functional.binary_cross_entropy_with_logits(logits, gold)
+        loss.backward()
+        opt.step()
+
+    probs = torch.sigmoid(scorer(boundary_states, rel_query, cands, pairs).detach())
+    pred = (probs > 0.5).float()
+    assert torch.equal(pred, gold), (probs, gold)
+
+
+def test_boundary_model_wires_sparse_relation_loss():
+    from gliner2 import ExtractorConfig
+    from gliner2.inference.engine import BoundaryExtractor
+    from gliner2.processor import SamplingConfig, SchemaTransformer
+    from gliner2.training import ExtractorCollator
+    from tests.fixtures.tiny_boundary_checkpoint import TINY_BOUNDARY_HEAD
+    from tests.fixtures.tiny_encoder import build_tiny_encoder_config
+    from tests.fixtures.tiny_tokenizer import build_tiny_tokenizer
+
+    tokenizer = build_tiny_tokenizer()
+    head = dict(TINY_BOUNDARY_HEAD)
+    head.update(enable_relations=True)
+    model = BoundaryExtractor(
+        ExtractorConfig(
+            model_name="tiny-bert-fixture",
+            architecture="boundary",
+            boundary_head=head,
+            token_pooling="first",
+        ),
+        encoder_config=build_tiny_encoder_config(vocab_size=len(tokenizer)),
+        tokenizer=tokenizer,
+    )
+    processor = SchemaTransformer(
+        tokenizer=tokenizer,
+        sampling_config=SamplingConfig(
+            remove_relations_prob=0.0,
+            swap_head_tail_prob=0.0,
+            synthetic_entity_label_prob=0.0,
+        ),
+    )
+    collator = ExtractorCollator(processor, is_training=True, architecture="boundary")
+    batch = collator([(
+        "Alice works for Acme",
+        {"relations": [{"works_for": {"head": "Alice", "tail": "Acme"}}]},
+    )])
+    model.train()
+    output = model(batch)
+    assert "relation_scorer" in model.task_module_names()
+    assert output.losses["relation_loss"].requires_grad
+
+    # Exercise public-boundary relation decoding with non-self synthetic
+    # endpoint proposals; an untrained proposer is not expected to supply them.
+    with torch.no_grad():
+        model.relation_scorer.mlp[-1].bias.fill_(10.0)
+    candidates = CandidateTensorBatch(
+        indices=torch.tensor([[[[0, 1]], [[3, 4]]]]),
+        proposal_logits=torch.zeros(1, 2, 1),
+        pair_logits=torch.full((1, 2, 1), 5.0),
+        valid_mask=torch.ones(1, 2, 1, dtype=torch.bool),
+        query_mask=torch.ones(1, 2, dtype=torch.bool),
+    )
+    decoded = model._decode_relations(
+        0,
+        {
+            "rel_specs": [[{
+                "spec": RelationTypeSpec("works_for", (0,), (1,)),
+                "query_state": torch.zeros(model.hidden_size),
+            }]],
+            "text_states": torch.zeros(1, 4, model.hidden_size),
+        },
+        candidates,
+        {"relation_metadata": {}},
+        threshold=0.5,
+        offset=0,
+        start_map=[0, 6, 12, 16],
+        end_map=[5, 11, 15, 20],
+        text="Alice works for Acme",
+        text_len=4,
+        include_confidence=False,
+        include_spans=True,
+    )
+    assert decoded["works_for"] == [{
+        "head": {"text": "Alice", "start": 0, "end": 5},
+        "tail": {"text": "Acme", "start": 16, "end": 20},
+    }]


### PR DESCRIPTION
## Summary

This PR adds experimental, trainable sparse relation extraction to the GLiNER2 boundary architecture.

Instead of constructing a dense all-pairs relation matrix, the boundary model:

1. Proposes sparse head and tail spans for each requested relation.
2. Keeps only the top configured endpoint candidates.
3. Scores a capped head × tail cross-product.
4. Decodes non-self relation pairs into the existing public relation output format.

This keeps relation-pair work bounded by the candidate caps, rather than sequence length squared.

### Included

- Add `SparseRelationScorer` for scoring sparse head/tail relation pairs.
- Add `TypedRelationPairGenerator` with:
  - capped head candidates,
  - capped tail candidates,
  - capped pair count,
  - self-pair filtering.
- Add relation configuration:
  - `enable_relations`
  - `relation_heads_per_type`
  - `relation_tails_per_type`
  - `relation_pair_cap`
  - `relation_loss_weight`
- Add relation-pair BCE training loss over gold head/tail spans.
- Add boundary runtime decoding and formatting for relation outputs.
- Add `relation_scorer` as a LoRA-compatible `relation_head` target.
- Add architecture-neutral sparse candidate-score utilities for future Joint IE optimization.
- Keep relation decoding fully separate from PR 2 record/event decoding.
- Add sparse-pair generation, scorer overfit, model-loss, runtime-decode, and Joint IE bridge tests.

## Usage

Create a boundary model with relation support enabled:

```python
from gliner2 import BoundaryExtractor, ExtractorConfig

model = BoundaryExtractor(
    ExtractorConfig(
        model_name="microsoft/deberta-v3-xsmall",
        architecture="boundary",
        token_pooling="first",
        boundary_head={
            "boundary_dim": 96,
            "pair_dim": 96,
            "enable_relations": True,
            "relation_heads_per_type": 32,
            "relation_tails_per_type": 32,
            "relation_pair_cap": 128,
            "relation_loss_weight": 1.0,
        },
    )
)
```

Define relation types through the existing schema API:

```python
from gliner2.inference.schema import Schema

schema = Schema().relations({
    "works_for": {"threshold": 0.60},
    "founded": {"threshold": 0.65},
})
```

Extract relations:

```python
text = (
    "Alice works for Acme. "
    "Bob founded Example Labs."
)

result = model.extract(text, schema, include_spans=True)

print(result)
# {
#   "relations": {
#     "works_for": [
#       {
#         "head": {"text": "Alice", "start": 0, "end": 5},
#         "tail": {"text": "Acme", "start": 16, "end": 20},
#       }
#     ],
#     "founded": [
#       {
#         "head": {"text": "Bob", "start": 22, "end": 25},
#         "tail": {"text": "Example Labs", "start": 34, "end": 46},
#       }
#     ],
#   }
# }
```

Relation-only extraction uses the same public API:

```python
result = model.extract_relations(
    "Alice works for Acme.",
    relation_types=["works_for"],
)
```

## Training

Training examples use the existing relation annotation format:

```python
from gliner2.training.data import InputExample, Relation

examples = [
    InputExample(
        text="Alice works for Acme.",
        relations=[
            Relation(
                relation_type="works_for",
                head="Alice",
                tail="Acme",
            )
        ],
    )
]
```

The boundary head learns endpoint spans, while the sparse relation scorer learns which proposed head/tail pairs are valid relations.

## Complexity

For each relation type:

```text
dense pair scoring:    O(N²)
sparse boundary path:  O(Rh × Rt)
```

Where:
- `Rh` = `relation_heads_per_type`
- `Rt` = `relation_tails_per_type`

The final pair set is additionally bounded by `relation_pair_cap`.

## Scope and limitations

- Experimental boundary-only feature; checkpoints must be created with `enable_relations=True`.
- Relation candidates and both endpoints must fit inside one encoded window.
- Cross-window relation merging is not supported.
- This PR learns directed `head`/`tail` relation pairs from existing relation schemas.
- Entity-type endpoint constraints and globally constrained Joint IE optimization are deferred to a follow-up PR.
- Records/events continue to use their independent PR 2 decoder path; relations are not compiled as record specs.

## Test plan

- [x] Sparse typed/capped pairing tests
- [x] Self-pair filtering test
- [x] Relation scorer synthetic overfit test
- [x] Boundary model relation-loss integration test
- [x] Boundary runtime sparse relation decode test
- [x] Joint IE candidate-score bridge and optimizer tests
- [x] Fast boundary/config/public API regression suite — 86 passed
- [x] `git diff --check` and staged diff check