### PR TITLE
Fix NameError in extract_entities_long; collapse duplicate surfaces when spans are stripped

### DIFF
--- a/gliner2/inference/chunking.py
+++ b/gliner2/inference/chunking.py
@@ -296,7 +296,19 @@ _SPAN_RESERVED = frozenset({"text", "confidence", "start", "end"})
 
 def _strip_span_metadata(value: Any, include_confidence: bool, include_spans: bool) -> Any:
     if isinstance(value, list):
-        return [_strip_span_metadata(item, include_confidence, include_spans) for item in value]
+        stripped_items = [
+            _strip_span_metadata(item, include_confidence, include_spans) for item in value
+        ]
+        # Spans are deduplicated by position in _dedupe_items, which correctly
+        # keeps the same surface text at different offsets. Once the offsets are
+        # stripped, though, those distinct mentions become identical strings that
+        # no caller can tell apart, so on a long document a term repeated 300
+        # times is returned 300 times. Collapse them, preserving first-seen
+        # order. Only bare strings are affected: anything still carrying
+        # confidence, offsets or attribute payloads stays untouched.
+        if stripped_items and all(isinstance(item, str) for item in stripped_items):
+            return list(dict.fromkeys(stripped_items))
+        return stripped_items
 
     if isinstance(value, dict):
         if _is_span_dict(value):

--- a/gliner2/inference/runtime.py
+++ b/gliner2/inference/runtime.py
@@ -1222,6 +1222,7 @@ class ExtractorRuntimeMixin:
         format_results: bool = True,
         include_confidence: bool = False,
         include_spans: bool = False,
+        overlap_policy: Optional[str] = None,
     ) -> Dict:
         """Extract entities from a long document with overlapping word chunks."""
         schema = self.create_schema().entities(entity_types)


### PR DESCRIPTION
Two independent fixes to the long-document path, found while serving GLiNER2 behind an HTTP API. Happy to split into separate PRs if you prefer.

## 1. `extract_entities_long` raises `NameError` on every call

`extract_entities_long` forwards `overlap_policy=overlap_policy` to `extract_long`, but its own signature never declares the parameter:

```python
model = GLiNER2.from_pretrained("fastino/gliner2-base-v1")
model.extract_entities_long("some long document ...", ["person"])
# NameError: name 'overlap_policy' is not defined
```

`extract_long` and `batch_extract_long` both declare `overlap_policy: Optional[str] = None`, so this looks like one wrapper missed when the parameter was threaded through. `batch_extract_entities_long` is unaffected because it does not forward the name — which is why the batch path works and the single-text path does not.

Fix adds the missing declaration, matching `extract_long`'s default.

## 2. Duplicate surfaces once spans are stripped

`_dedupe_items` deduplicates spans **by position**, which correctly keeps the same surface text at different offsets. When `include_spans` and `include_confidence` are both false, `_strip_span_metadata` then reduces those spans to bare strings — and the distinct positions become identical strings that no caller can tell apart.

On a long document this is very visible. A report mentioning "PostgreSQL" 300 times returns it 300 times:

```python
{"entities": {"database": ["PostgreSQL", "PostgreSQL", ...x300]}}
```

At that fidelity the repeats carry no information — no offset to distinguish them, no confidence to rank them — so a caller can only discard them.

The fix collapses them while preserving first-seen document order, scoped to lists that reduce entirely to strings. Anything still carrying confidence, offsets or attribute-group payloads is untouched, so `include_spans=True` behaviour is unchanged.

Verified against `fastino/gliner2-base-v1` on a document repeating one sentence 120 times:

| mode | before | after |
| --- | --- | --- |
| formatted strings | `database`: ~200 entries | `database`: 3 unique, `location`: 1 unique |
| `include_spans=True` | 49 entries | 49 entries, all distinct positions preserved |

I read the note in the long-document tutorial about keeping distinct mentions at different document positions — that behaviour is preserved wherever positions are actually visible in the output. If you would rather have this behind an opt-in flag than as a default, say the word and I will rework it.

## Testing

`tests/inference` and `tests/processing` pass — 71 tests.