### PR TITLE
Optimize span scoring

### DIFF
--- a/benchmarks/benchmark_direct_span_full.py
+++ b/benchmarks/benchmark_direct_span_full.py
@@ -1,0 +1,1270 @@
+#!/usr/bin/env python3
+"""GLiNER2 exact-legacy vs current direct-span benchmark.
+
+One script, two fresh subprocesses:
+  * legacy: exact git commit a91fd1d2...
+  * current: the working tree on disk (including uncommitted patches)
+
+Primary measurement:
+  * controlled span-scaling grid over token length L and query count Q
+  * default grid: L={64,256}, Q={1,8,32}, B={1,8}
+
+Secondary measurements:
+  * entities / structures / relations / mixed: full end-to-end inference
+  * Joint-IE: batch_score() for speed, small full batch_extract() for parity
+  * training: real forward+backward on CUDA only
+
+CPU policy (automatic): 75% logical CPUs for PyTorch compute, 25% for
+DataLoader preprocessing. CUDA policy: 1 host compute/orchestration thread and
+all remaining logical CPUs as preprocessing workers. No MPS support.
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import torch
+
+LEGACY_COMMIT = "a91fd1d2c72debe43907296c8e375a036c6a4faf"
+VERSION = "exact-legacy-lq-scaling-unfold-baddbmm-v2"
+CURRENT_DIRECT_KERNEL = "unfold_baddbmm"
+
+ENTITY_TYPES = ["person", "organization", "location", "date", "product", "event"]
+RELATION_TYPES = ["works_for", "founded", "located_in", "acquired"]
+STRUCTURES = {
+    "employment": ["person::str", "organization::str", "location::str", "date::str"],
+    "event_record": ["name::str", "organization::str", "location::str", "date::str"],
+}
+TASKS = ("entities", "structures", "relations", "mixed", "joint")
+
+SEEDS = [
+    "Apple CEO Tim Cook announced a new iPhone in Cupertino on September 12, 2023.",
+    "Google CEO Sundar Pichai presented Gemini features in Mountain View.",
+    "Microsoft CEO Satya Nadella discussed Azure infrastructure in Seattle.",
+    "NVIDIA CEO Jensen Huang presented CUDA systems at GTC in San Jose.",
+    "AMD CEO Lisa Su introduced EPYC processors during an event in Austin.",
+    "Sarah Chen founded Nova Robotics in Boston in 2021 and opened an office in Berlin.",
+    "Daniel Ortiz works for Horizon Systems in Madrid.",
+    "Atlas Analytics acquired BrightData Labs in London in March 2024.",
+    "Maria Ivanova joined CloudWorks in Sofia and presented Orion in Vienna.",
+    "Researchers from ETH Zurich and the University of Toronto presented work at NeurIPS.",
+]
+
+
+def csv(value: str) -> List[str]:
+    return [x.strip() for x in value.split(",") if x.strip()]
+
+
+def csv_int(value: str) -> List[int]:
+    return [int(x) for x in csv(value)]
+
+
+def csv_float(value: str) -> List[float]:
+    return [float(x) for x in csv(value)]
+
+
+def seed_everything(seed: int) -> None:
+    """Reset all RNGs used by data preparation/model dropout outside timed regions."""
+    random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    try:
+        import numpy as np
+        np.random.seed(seed % (2**32 - 1))
+    except ImportError:
+        pass
+
+
+def sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def reset_peak(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats(device)
+
+
+def peak_mb(device: torch.device) -> Optional[float]:
+    if device.type != "cuda":
+        return None
+    return torch.cuda.max_memory_allocated(device) / 2**20
+
+
+def clear(device: Optional[torch.device] = None) -> None:
+    gc.collect()
+    if device is not None and device.type == "cuda":
+        torch.cuda.empty_cache()
+
+
+def cpu_plan(device: str) -> Tuple[int, int, int]:
+    """Return (logical_cpus, torch_compute_threads, preprocessing_workers)."""
+    total = os.cpu_count() or 1
+    if device == "cpu":
+        if total == 1:
+            return 1, 1, 0
+        workers = max(1, round(total * 0.25))
+        workers = min(workers, total - 1)
+        return total, total - workers, workers
+    if device == "cuda":
+        return total, 1, max(0, total - 1)
+    raise ValueError(f"unsupported device: {device}")
+
+
+def set_torch_threads(n: int) -> None:
+    torch.set_num_threads(max(1, n))
+    try:
+        torch.set_num_interop_threads(1)
+    except RuntimeError:
+        pass
+
+
+def dtype_from_name(name: str) -> torch.dtype:
+    return {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}[name]
+
+
+def device_label(device: torch.device) -> str:
+    if device.type == "cuda":
+        return torch.cuda.get_device_name(device)
+    return platform.processor() or platform.machine() or "CPU"
+
+
+def available_devices(requested: Sequence[str]) -> List[str]:
+    if requested == ["auto"]:
+        return ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+    bad = set(requested) - {"cpu", "cuda"}
+    if bad:
+        raise ValueError(f"only cpu,cuda are supported; got {sorted(bad)}")
+    return [d for d in requested if d != "cuda" or torch.cuda.is_available()]
+
+
+def dtypes_for(device: str, requested: Sequence[str]) -> List[str]:
+    if requested != ["auto"]:
+        return list(requested)
+    if device == "cpu":
+        return ["fp32", "bf16", "fp16"]
+    out = ["fp32", "fp16"]
+    if torch.cuda.is_bf16_supported():
+        out.append("bf16")
+    return out
+
+
+def jsonable(obj: Any) -> Any:
+    if obj is None or isinstance(obj, (str, int, bool)):
+        return obj
+    if isinstance(obj, float):
+        if math.isnan(obj):
+            return "NaN"
+        if math.isinf(obj):
+            return "Infinity" if obj > 0 else "-Infinity"
+        return obj
+    if torch.is_tensor(obj):
+        if obj.numel() == 1:
+            return float(obj.detach().float().cpu())
+        return obj.detach().cpu().tolist()
+    if hasattr(obj, "to_dict"):
+        try:
+            return jsonable(obj.to_dict(include_confidence=True, include_spans=True))
+        except TypeError:
+            try:
+                return jsonable(obj.to_dict())
+            except Exception:
+                pass
+    if isinstance(obj, dict):
+        return {str(k): jsonable(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [jsonable(v) for v in obj]
+    if hasattr(obj, "__dict__"):
+        return {k: jsonable(v) for k, v in vars(obj).items() if not k.startswith("_")}
+    return str(obj)
+
+
+CONF_KEYS = {"confidence", "score", "probability"}
+
+
+def semantic(obj: Any) -> Any:
+    obj = jsonable(obj)
+    if isinstance(obj, dict):
+        return {k: semantic(v) for k, v in sorted(obj.items()) if k not in CONF_KEYS}
+    if isinstance(obj, list):
+        vals = [semantic(v) for v in obj]
+        try:
+            return sorted(vals, key=lambda x: json.dumps(x, sort_keys=True, ensure_ascii=False))
+        except Exception:
+            return vals
+    return obj
+
+
+def confidences(obj: Any, out: Optional[List[float]] = None) -> List[float]:
+    out = [] if out is None else out
+    obj = jsonable(obj)
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k in CONF_KEYS and isinstance(v, (int, float)):
+                out.append(float(v))
+            else:
+                confidences(v, out)
+    elif isinstance(obj, list):
+        for v in obj:
+            confidences(v, out)
+    return sorted(out)
+
+
+def signature(outputs: Sequence[Any]) -> Dict[str, Any]:
+    hashes, confs = [], []
+    for output in outputs:
+        payload = json.dumps(semantic(output), sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+        hashes.append(hashlib.sha256(payload.encode()).hexdigest())
+        confs.append(confidences(output))
+    return {"hashes": hashes, "confidences": confs}
+
+
+def compare_signature(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:
+    n = max(len(a["hashes"]), len(b["hashes"]))
+    exact = sum(x == y for x, y in zip(a["hashes"], b["hashes"]))
+    diffs: List[float] = []
+    shape_mismatch = 0
+    for x, y in zip(a["confidences"], b["confidences"]):
+        if len(x) != len(y):
+            shape_mismatch += 1
+        else:
+            diffs.extend(abs(float(i) - float(j)) for i, j in zip(x, y))
+    return {
+        "documents": n,
+        "exact_documents": exact,
+        "mismatched_documents": n - exact,
+        "match_rate": exact / max(1, n),
+        "confidence_shape_mismatches": shape_mismatch,
+        "confidence_mean_abs": statistics.mean(diffs) if diffs else 0.0,
+        "confidence_max_abs": max(diffs) if diffs else 0.0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Corpus
+# ---------------------------------------------------------------------------
+
+
+def load_corpus(path: Path, limit: int) -> List[str]:
+    if path.suffix.lower() == ".jsonl":
+        rows = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            value = json.loads(line)
+            rows.append(value["text"] if isinstance(value, dict) else str(value))
+            if limit and len(rows) >= limit:
+                break
+        return rows
+    if path.suffix.lower() == ".json":
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(value, dict):
+            value = value.get("texts", value.get("documents", value.get("data", [])))
+        rows = [x["text"] if isinstance(x, dict) else str(x) for x in value]
+        return rows[:limit] if limit else rows
+    rows = [x.strip() for x in path.read_text(encoding="utf-8").splitlines() if x.strip()]
+    return rows[:limit] if limit else rows
+
+
+def generate_corpus(model_id: str, docs: int, target_lengths: Sequence[int], seed: int) -> List[str]:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    rng = random.Random(seed)
+    out = []
+    for i in range(docs):
+        target = target_lengths[i % len(target_lengths)]
+        parts = []
+        while True:
+            parts.append(rng.choice(SEEDS))
+            text = " ".join(parts)
+            if len(tokenizer.encode(text, add_special_tokens=False)) >= target:
+                break
+        words = text.split()
+        lo, hi = 1, len(words)
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            candidate = " ".join(words[:mid])
+            if len(tokenizer.encode(candidate, add_special_tokens=False)) <= target:
+                lo = mid
+            else:
+                hi = mid - 1
+        out.append(" ".join(words[:lo]))
+    return out
+
+
+
+def generate_exact_token_corpus(
+    model_id: str,
+    docs: int,
+    target_tokens: int,
+    seed: int,
+) -> List[str]:
+    """Generate deterministic texts that re-tokenize to exactly target_tokens."""
+    from transformers import AutoTokenizer
+
+    if target_tokens <= 0:
+        raise ValueError("target_tokens must be positive")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    rng = random.Random(seed)
+    out: List[str] = []
+
+    for _ in range(docs):
+        parts: List[str] = []
+        ids: List[int] = []
+        while len(ids) < target_tokens + 32:
+            parts.append(rng.choice(SEEDS))
+            ids = tokenizer.encode(" ".join(parts), add_special_tokens=False)
+
+        # Decode an exact token prefix. For the tokenizer used by the benchmark,
+        # encode(decode(prefix)) should normally round-trip exactly.
+        candidate = tokenizer.decode(
+            ids[:target_tokens],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+        actual = tokenizer.encode(candidate, add_special_tokens=False)
+
+        # A normalization-sensitive tokenizer can occasionally change the count
+        # after decode/re-encode. Search nearby prefixes before giving up.
+        if len(actual) != target_tokens:
+            found = None
+            lo = max(1, target_tokens - 16)
+            hi = min(len(ids), target_tokens + 16)
+            for n in range(lo, hi + 1):
+                c = tokenizer.decode(
+                    ids[:n],
+                    skip_special_tokens=True,
+                    clean_up_tokenization_spaces=False,
+                )
+                if len(tokenizer.encode(c, add_special_tokens=False)) == target_tokens:
+                    found = c
+                    break
+            if found is None:
+                raise RuntimeError(
+                    f"could not construct text with exactly {target_tokens} tokens"
+                )
+            candidate = found
+
+        out.append(candidate)
+
+    return out
+
+
+def corpus_hash(texts: Sequence[str]) -> str:
+    h = hashlib.sha256()
+    for text in texts:
+        h.update(text.encode())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Inference tasks
+# ---------------------------------------------------------------------------
+
+
+def structure_schema(model):
+    schema = model.create_schema()
+    for name, fields in STRUCTURES.items():
+        builder = schema.structure(name)
+        for spec in fields:
+            field, dtype = spec.split("::", 1)
+            builder.field(field, dtype=dtype)
+    return schema
+
+
+def mixed_schema(model):
+    schema = model.create_schema()
+    schema.entities(["person", "organization", "location", "date", "product"])
+    schema.classification("document_type", ["news", "technical", "business", "other"])
+    schema.structure("employment").field("person").field("organization").field("location")
+    schema.structure("event_record").field("name").field("date").field("location")
+    schema.relations(["works_for", "located_in", "founded"])
+    return schema
+
+
+def standard_schema(model, task: str):
+    if task == "entities":
+        return model.create_schema().entities(ENTITY_TYPES)
+    if task == "structures":
+        return structure_schema(model)
+    if task == "relations":
+        return model.create_schema().relations(RELATION_TYPES)
+    if task == "mixed":
+        return mixed_schema(model)
+    raise ValueError(task)
+
+
+def run_standard(model, task: str, texts: Sequence[str], bs: int, threshold: float, max_len: int, workers: int):
+    return model.batch_extract(
+        list(texts), standard_schema(model, task),
+        batch_size=bs,
+        threshold=threshold,
+        num_workers=workers,
+        format_results=True,
+        include_confidence=True,
+        include_spans=True,
+        max_len=max_len,
+    )
+
+
+
+def scaling_entity_types(query_count: int) -> List[str]:
+    """Deterministic synthetic entity labels used only for controlled Q scaling."""
+    if query_count <= 0:
+        raise ValueError("query_count must be positive")
+    return [f"benchmark_entity_{i:02d}" for i in range(query_count)]
+
+
+def run_scaling(
+    model,
+    texts: Sequence[str],
+    query_count: int,
+    bs: int,
+    max_len: int,
+    workers: int,
+):
+    """Controlled E2E entity extraction for a fixed token length and query count.
+
+    Synthetic labels make Q explicit while keeping the model/public inference path
+    identical between exact legacy and current. Formatting/confidence/span output is
+    disabled so the table is dominated by model/scoring work rather than result
+    serialization.
+    """
+    cache = getattr(model, "_benchmark_scaling_schemas", None)
+    if cache is None:
+        cache = {}
+        setattr(model, "_benchmark_scaling_schemas", cache)
+    schema = cache.get(query_count)
+    if schema is None:
+        schema = model.create_schema().entities(scaling_entity_types(query_count))
+        cache[query_count] = schema
+
+    return model.batch_extract(
+        list(texts),
+        schema,
+        batch_size=bs,
+        threshold=0.5,
+        num_workers=workers,
+        format_results=False,
+        include_confidence=False,
+        include_spans=False,
+        max_len=max_len,
+    )
+
+
+def joint_components(model):
+    from gliner2.joint_ie import JointIE, JointIEConfig
+    from gliner2.joint_ie.schema import JointSchema
+
+    schema = JointSchema().entities(["person", "organization", "location", "product"])
+    schema.relation("works_for", head=["person"], tail=["organization"])
+    schema.relation("located_in", head=["organization"], tail=["location"])
+    return JointIE(model), schema, JointIEConfig
+
+
+def joint_config(JointIEConfig, bs: int, max_len: int):
+    return JointIEConfig(
+        optimizer="greedy",
+        batch_size=bs,
+        count_top_k=2,
+        max_len=max_len,
+        include_confidence=True,
+        include_spans=True,
+    )
+
+
+def run_joint_score(model, texts: Sequence[str], bs: int, max_len: int) -> int:
+    engine, schema, JointIEConfig = joint_components(model)
+    previous = os.environ.get("TOKENIZERS_PARALLELISM")
+    os.environ["TOKENIZERS_PARALLELISM"] = "true"
+    try:
+        compiled = engine.compile_schema(schema)
+        lattices = engine.batch_score(
+            list(texts), compiled, config=joint_config(JointIEConfig, bs, max_len)
+        )
+        return len(lattices)
+    finally:
+        if previous is None:
+            os.environ.pop("TOKENIZERS_PARALLELISM", None)
+        else:
+            os.environ["TOKENIZERS_PARALLELISM"] = previous
+
+
+def run_joint_full(model, texts: Sequence[str], bs: int, max_len: int):
+    engine, schema, JointIEConfig = joint_components(model)
+    previous = os.environ.get("TOKENIZERS_PARALLELISM")
+    os.environ["TOKENIZERS_PARALLELISM"] = "true"
+    try:
+        results = engine.batch_extract(
+            list(texts), schema, config=joint_config(JointIEConfig, bs, max_len)
+        )
+        return [jsonable(x) for x in results]
+    finally:
+        if previous is None:
+            os.environ.pop("TOKENIZERS_PARALLELISM", None)
+        else:
+            os.environ["TOKENIZERS_PARALLELISM"] = previous
+
+
+def timed(fn, device: torch.device, repeats: int) -> Tuple[float, List[float], Optional[float]]:
+    times, peaks = [], []
+    for _ in range(repeats):
+        reset_peak(device)
+        sync(device)
+        t0 = time.perf_counter()
+        fn()
+        sync(device)
+        times.append(time.perf_counter() - t0)
+        p = peak_mb(device)
+        if p is not None:
+            peaks.append(p)
+    return statistics.median(times), times, max(peaks) if peaks else None
+
+
+# ---------------------------------------------------------------------------
+# Training
+# ---------------------------------------------------------------------------
+
+
+def training_examples():
+    from gliner2.training.data import Classification, InputExample, Relation, Structure
+
+    return [
+        InputExample(
+            text="Tim Cook works for Apple in Cupertino and presented the iPhone.",
+            entities={"person": ["Tim Cook"], "organization": ["Apple"], "location": ["Cupertino"], "product": ["iPhone"]},
+            classifications=[Classification("document_type", ["news", "technical", "business"], "news")],
+            structures=[Structure("employment", person="Tim Cook", organization="Apple", location="Cupertino")],
+            relations=[Relation("works_for", head="Tim Cook", tail="Apple")],
+        ),
+        InputExample(
+            text="Sundar Pichai works for Google in Mountain View and discussed Gemini.",
+            entities={"person": ["Sundar Pichai"], "organization": ["Google"], "location": ["Mountain View"], "product": ["Gemini"]},
+            classifications=[Classification("document_type", ["news", "technical", "business"], "technical")],
+            structures=[Structure("employment", person="Sundar Pichai", organization="Google", location="Mountain View")],
+            relations=[Relation("works_for", head="Sundar Pichai", tail="Google")],
+        ),
+        InputExample(
+            text="Sarah Chen founded Nova Robotics in Boston in 2021.",
+            entities={"person": ["Sarah Chen"], "organization": ["Nova Robotics"], "location": ["Boston"], "date": ["2021"]},
+            classifications=[Classification("document_type", ["news", "technical", "business"], "business")],
+            structures=[Structure("event_record", name="Nova Robotics", date="2021", location="Boston")],
+            relations=[Relation("founded", head="Sarah Chen", tail="Nova Robotics")],
+        ),
+        InputExample(
+            text="Daniel Ortiz works for Horizon Systems in Madrid.",
+            entities={"person": ["Daniel Ortiz"], "organization": ["Horizon Systems"], "location": ["Madrid"]},
+            classifications=[Classification("document_type", ["news", "technical", "business"], "business")],
+            structures=[Structure("employment", person="Daniel Ortiz", organization="Horizon Systems", location="Madrid")],
+            relations=[Relation("works_for", head="Daniel Ortiz", tail="Horizon Systems")],
+        ),
+    ]
+
+
+def training_batch(model, bs: int, max_len: int, device: torch.device, dtype: torch.dtype):
+    from gliner2.training.trainer import ExtractorCollator, ExtractorDataset
+
+    model.processor.change_mode(is_training=True)
+    examples = training_examples()
+    rows = [examples[i % len(examples)] for i in range(bs)]
+    dataset = ExtractorDataset.from_examples(rows, shuffle=False, validate=True)
+    collator = ExtractorCollator(model.processor, is_training=True, max_len=max_len, architecture=model.architecture)
+    return collator([dataset[i] for i in range(len(dataset))]).to(device, dtype=dtype)
+
+
+def loss_dict(out: Dict[str, Any]) -> Dict[str, float]:
+    result = {}
+    for key in ("total_loss", "classification_loss", "structure_loss", "count_loss"):
+        if key in out:
+            value = out[key]
+            result[key] = float(value.detach().float().cpu()) if torch.is_tensor(value) else float(value)
+    return result
+
+
+def benchmark_training(
+    model,
+    device: torch.device,
+    dtype: torch.dtype,
+    sizes: Sequence[int],
+    repeats: int,
+    warmup: int,
+    max_len: int,
+    base_seed: int,
+):
+    """Benchmark real forward+backward with identical RNG state across variants.
+
+    Batch construction and every model invocation are seeded before entering the
+    timed region. This keeps schema/data randomization and dropout comparable
+    between the exact-legacy and current subprocesses without timing RNG setup.
+    """
+    rows = []
+    for bs in sizes:
+        try:
+            batch_seed = base_seed + 100_000 + bs
+            seed_everything(batch_seed)
+            batch = training_batch(model, bs, max_len, device, dtype)
+
+            # Eval-mode loss is the cross-process numerical parity reference.
+            # Re-seed even in eval mode because this makes the benchmark robust
+            # to any stochastic preprocessing/model component added later.
+            model.eval()
+            eval_seed = base_seed + 200_000 + bs
+            seed_everything(eval_seed)
+            deterministic = loss_dict(model(batch))
+
+            model.train()
+            for i in range(warmup):
+                model.zero_grad(set_to_none=True)
+                seed_everything(base_seed + 300_000 + bs * 1_000 + i)
+                model(batch)["total_loss"].backward()
+            sync(device)
+
+            times, peaks = [], []
+            for i in range(repeats):
+                model.zero_grad(set_to_none=True)
+                # Seed before reset/sync/timer so RNG setup is not benchmarked.
+                seed_everything(base_seed + 400_000 + bs * 1_000 + i)
+                reset_peak(device)
+                sync(device)
+                t0 = time.perf_counter()
+                model(batch)["total_loss"].backward()
+                sync(device)
+                times.append(time.perf_counter() - t0)
+                p = peak_mb(device)
+                if p is not None:
+                    peaks.append(p)
+            med = statistics.median(times)
+            rows.append({
+                "batch_size": bs,
+                "training_batch_seed": batch_seed,
+                "eval_seed": eval_seed,
+                "samples_per_second": bs / med,
+                "median_seconds": med,
+                "times": times,
+                "peak_allocated_mb": max(peaks) if peaks else None,
+                "deterministic_eval_loss": deterministic,
+            })
+            del batch
+        except (RuntimeError, TypeError, ValueError, NotImplementedError) as exc:
+            rows.append({"batch_size": bs, "error": f"{type(exc).__name__}: {exc}"})
+            clear(device)
+    model.eval()
+    model.processor.change_mode(is_training=False)
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+
+def load_model(model_id: str, device: torch.device, dtype: torch.dtype, variant: str):
+    from gliner2 import GLiNER2
+
+    model = GLiNER2.from_pretrained(model_id, map_location=str(device)).to(device=device, dtype=dtype)
+    model.eval()
+    if variant == "current":
+        needed = [
+            (model, "compute_span_scores_batched"),
+            (model, "_compute_training_span_scores_batched"),
+            (model.span_rep, "score_queries"),
+        ]
+        missing = [name for obj, name in needed if not hasattr(obj, name)]
+        if missing:
+            raise RuntimeError("current checkout is missing direct-span patch: " + ", ".join(missing))
+    return model
+
+
+def worker(repo: Path, variant: str, config_path: Path, corpus_path: Path, output_path: Path) -> int:
+    repo = repo.resolve()
+    sys.path.insert(0, str(repo))
+    import gliner2
+
+    if repo not in Path(gliner2.__file__).resolve().parents:
+        raise RuntimeError(f"wrong gliner2 imported: {gliner2.__file__}")
+
+    cfg = json.loads(config_path.read_text())
+    corpus_payload = json.loads(corpus_path.read_text())
+    if isinstance(corpus_payload, list):
+        # Backward-compatible worker input.
+        texts = corpus_payload
+        scaling_corpora = {}
+    else:
+        texts = corpus_payload["main"]
+        scaling_corpora = {
+            int(k): v for k, v in corpus_payload.get("scaling", {}).items()
+        }
+
+    result = {
+        "variant": variant,
+        "direct_kernel": CURRENT_DIRECT_KERNEL if variant == "current" else "legacy_span_materialization",
+        "benchmark_seed": cfg["seed"],
+        "corpus_sha256": corpus_hash(texts),
+        "scaling_corpus_sha256": {
+            str(k): corpus_hash(v) for k, v in sorted(scaling_corpora.items())
+        },
+        "runs": [],
+    }
+
+    for dev_name in available_devices(cfg["devices"]):
+        total, compute_threads, workers = cpu_plan(dev_name)
+        set_torch_threads(compute_threads)
+        os.environ["TOKENIZERS_PARALLELISM"] = "false" if workers else "true"
+        print(f"\n[{variant}] {dev_name}: logical={total} compute_threads={compute_threads} preprocess_workers={workers}", flush=True)
+
+        for dtype_name in dtypes_for(dev_name, cfg["dtypes"]):
+            if dev_name == "cuda" and dtype_name == "bf16" and not torch.cuda.is_bf16_supported():
+                continue
+            device, dtype = torch.device(dev_name), dtype_from_name(dtype_name)
+            run = {"device": dev_name, "device_name": device_label(device), "dtype": dtype_name, "tasks": {}}
+            print(f"  dtype={dtype_name}", flush=True)
+            try:
+                model = load_model(cfg["model"], device, dtype, variant)
+
+                # Primary benchmark: controlled L x Q scaling. Batch size is kept
+                # deliberately small as a secondary axis (default B={1,8}).
+                scaling_rows = []
+                if cfg.get("scaling", True):
+                    print("    controlled L x Q scaling", flush=True)
+                    for token_length in cfg["scaling_token_lengths"]:
+                        scale_texts = scaling_corpora.get(int(token_length), [])
+                        if not scale_texts:
+                            continue
+                        for query_count in cfg["scaling_query_counts"]:
+                            for bs in cfg["batch_sizes"]:
+                                warm = scale_texts[:min(
+                                    len(scale_texts),
+                                    max(cfg["warmup_docs"], bs * 2),
+                                )]
+                                try:
+                                    run_scaling(
+                                        model, warm, query_count, bs,
+                                        cfg["max_len"], workers,
+                                    )
+                                    fn = lambda tl=token_length, q=query_count, bs=bs: run_scaling(
+                                        model,
+                                        scaling_corpora[int(tl)],
+                                        q,
+                                        bs,
+                                        cfg["max_len"],
+                                        workers,
+                                    )
+                                    med, times, peak = timed(fn, device, cfg["repeats"])
+                                    dps = len(scale_texts) / med
+                                    scaling_rows.append({
+                                        "tokens": int(token_length),
+                                        "queries": int(query_count),
+                                        "batch_size": int(bs),
+                                        "docs_per_second": dps,
+                                        "median_seconds": med,
+                                        "times": times,
+                                        "peak_allocated_mb": peak,
+                                    })
+                                    print(
+                                        f"      L={token_length:<3} Q={query_count:<2} "
+                                        f"B={bs:<2} {dps:9.2f} docs/s",
+                                        flush=True,
+                                    )
+                                except (RuntimeError, TypeError, ValueError, NotImplementedError) as exc:
+                                    scaling_rows.append({
+                                        "tokens": int(token_length),
+                                        "queries": int(query_count),
+                                        "batch_size": int(bs),
+                                        "error": f"{type(exc).__name__}: {exc}",
+                                    })
+                                    print(
+                                        f"      L={token_length:<3} Q={query_count:<2} "
+                                        f"B={bs:<2} SKIP {exc}",
+                                        flush=True,
+                                    )
+                                    clear(device)
+                run["scaling"] = scaling_rows
+
+                for task in cfg["tasks"]:
+                    print(f"    task={task}", flush=True)
+                    speed_rows = []
+                    for bs in cfg["batch_sizes"]:
+                        warm = texts[:min(len(texts), max(cfg["warmup_docs"], bs * 2))]
+                        try:
+                            if task == "joint":
+                                run_joint_score(model, warm, bs, cfg["max_len"])
+                                fn = lambda: run_joint_score(model, texts, bs, cfg["max_len"])
+                                scope = "joint_batch_score"
+                            else:
+                                run_standard(model, task, warm, bs, cfg["speed_threshold"], cfg["max_len"], workers)
+                                fn = lambda task=task, bs=bs: run_standard(
+                                    model, task, texts, bs, cfg["speed_threshold"], cfg["max_len"], workers
+                                )
+                                scope = "end_to_end"
+                            med, times, peak = timed(fn, device, cfg["repeats"])
+                            speed_rows.append({
+                                "batch_size": bs,
+                                "docs_per_second": len(texts) / med,
+                                "median_seconds": med,
+                                "times": times,
+                                "peak_allocated_mb": peak,
+                            })
+                            print(f"      bs={bs:<3} {len(texts)/med:9.2f} docs/s", flush=True)
+                        except (RuntimeError, TypeError, ValueError, NotImplementedError) as exc:
+                            speed_rows.append({"batch_size": bs, "error": f"{type(exc).__name__}: {exc}"})
+                            print(f"      bs={bs:<3} SKIP {exc}", flush=True)
+                            clear(device)
+
+                    good = [r["batch_size"] for r in speed_rows if "error" not in r]
+                    qbs = cfg["quality_batch_size"] or (max(good) if good else 1)
+                    qn = min(len(texts), cfg["joint_quality_docs"] if task == "joint" else cfg["quality_docs"])
+                    qtexts = texts[:qn]
+                    quality = []
+                    if task == "joint":
+                        try:
+                            quality.append({"threshold": None, **signature(run_joint_full(model, qtexts, qbs, cfg["max_len"]))})
+                        except Exception as exc:
+                            quality.append({"threshold": None, "error": f"{type(exc).__name__}: {exc}"})
+                    else:
+                        for threshold in cfg["thresholds"]:
+                            try:
+                                out = run_standard(model, task, qtexts, qbs, threshold, cfg["max_len"], workers)
+                                quality.append({"threshold": threshold, **signature(out)})
+                            except Exception as exc:
+                                quality.append({"threshold": threshold, "error": f"{type(exc).__name__}: {exc}"})
+                    run["tasks"][task] = {"speed_scope": scope, "speed": speed_rows, "quality": quality}
+
+                if cfg["training"] and dev_name == "cuda":
+                    print("    training forward+backward", flush=True)
+                    run["training"] = benchmark_training(
+                        model, device, dtype, cfg["training_batch_sizes"],
+                        cfg["training_repeats"], cfg["training_warmup"], cfg["max_len"],
+                        cfg["seed"],
+                    )
+                del model
+                clear(device)
+            except (RuntimeError, TypeError, ValueError, NotImplementedError) as exc:
+                run["error"] = f"{type(exc).__name__}: {exc}"
+                print(f"    CONFIG FAIL: {run['error']}", flush=True)
+                clear(device)
+            result["runs"].append(run)
+            output_path.write_text(json.dumps(result, indent=2))
+
+    output_path.write_text(json.dumps(result, indent=2))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Parent: export exact commit, run both, compare
+# ---------------------------------------------------------------------------
+
+
+def repo_root() -> Path:
+    here = Path(__file__).resolve().parent.parent
+    if (here / ".git").exists():
+        return here
+    return Path(subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip())
+
+
+def export_commit(repo: Path, commit: str, dest: Path) -> None:
+    subprocess.run(["git", "cat-file", "-e", f"{commit}^{{commit}}"], cwd=repo, check=True)
+    tar_path = dest.parent / "legacy.tar"
+    subprocess.run(["git", "archive", "--format=tar", "-o", str(tar_path), commit], cwd=repo, check=True)
+    dest.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tar_path) as tf:
+        tf.extractall(dest)
+    tar_path.unlink()
+
+
+def launch(script: Path, repo: Path, variant: str, cfg: Path, corpus: Path, out: Path) -> None:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    # Legacy and current run in separate Python processes. Python's hash seed
+    # affects set iteration order, and GLiNER2 schema preprocessing contains
+    # set -> list conversions for structure fields. Fix it explicitly so both
+    # workers construct identical schemas/batches before model-path comparison.
+    benchmark_seed = int(json.loads(cfg.read_text())["seed"])
+    env["PYTHONHASHSEED"] = str(benchmark_seed)
+    # Avoid inherited one-thread caps. Device-specific torch.set_num_threads() is
+    # applied inside the worker; these are only safe upper bounds for native libs.
+    total = str(os.cpu_count() or 1)
+    for name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS", "RAYON_NUM_THREADS"):
+        env[name] = total
+    env["OMP_DYNAMIC"] = "FALSE"
+    env["MKL_DYNAMIC"] = "FALSE"
+    env["TOKENIZERS_PARALLELISM"] = "false"
+    cmd = [
+        sys.executable, str(script), "--_worker", "--_repo", str(repo),
+        "--_variant", variant, "--_config", str(cfg), "--_corpus", str(corpus),
+        "--_worker-output", str(out),
+    ]
+    print("\n" + "=" * 88)
+    print(f"RUNNING {variant.upper()}: {repo}")
+    print("=" * 88, flush=True)
+    subprocess.run(cmd, cwd=repo, env=env, check=True)
+
+
+def indexed_runs(data: Dict[str, Any]) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    return {(r["device"], r["dtype"]): r for r in data["runs"]}
+
+
+def rows_by_bs(rows: Sequence[Dict[str, Any]]) -> Dict[int, Dict[str, Any]]:
+    return {int(r["batch_size"]): r for r in rows}
+
+
+def scaling_index(rows: Sequence[Dict[str, Any]]) -> Dict[Tuple[int, int, int], Dict[str, Any]]:
+    return {
+        (int(r["tokens"]), int(r["queries"]), int(r["batch_size"])): r
+        for r in rows
+    }
+
+
+def compare(legacy: Dict[str, Any], current: Dict[str, Any]) -> Dict[str, Any]:
+    out = {"configs": []}
+    lr, cr = indexed_runs(legacy), indexed_runs(current)
+    for key in sorted(set(lr) & set(cr)):
+        a, b = lr[key], cr[key]
+        cfg = {"device": key[0], "dtype": key[1], "tasks": {}}
+        if "error" in a or "error" in b:
+            cfg["error"] = {"legacy": a.get("error"), "current": b.get("error")}
+            out["configs"].append(cfg)
+            continue
+
+        scaling = []
+        sa, sb = scaling_index(a.get("scaling", [])), scaling_index(b.get("scaling", []))
+        for skey in sorted(set(sa) & set(sb)):
+            x, y = sa[skey], sb[skey]
+            row = {
+                "tokens": skey[0],
+                "queries": skey[1],
+                "batch_size": skey[2],
+            }
+            if "error" in x or "error" in y:
+                row.update({
+                    "legacy_error": x.get("error"),
+                    "current_error": y.get("error"),
+                })
+            else:
+                row.update({
+                    "legacy_docs_per_second": x["docs_per_second"],
+                    "current_docs_per_second": y["docs_per_second"],
+                    "speedup": x["median_seconds"] / y["median_seconds"],
+                    "legacy_peak_allocated_mb": x.get("peak_allocated_mb"),
+                    "current_peak_allocated_mb": y.get("peak_allocated_mb"),
+                })
+            scaling.append(row)
+        cfg["scaling"] = scaling
+
+        for task in sorted(set(a["tasks"]) & set(b["tasks"])):
+            at, bt = a["tasks"][task], b["tasks"][task]
+            speed = []
+            aa, bb = rows_by_bs(at["speed"]), rows_by_bs(bt["speed"])
+            for bs in sorted(set(aa) & set(bb)):
+                x, y = aa[bs], bb[bs]
+                if "error" in x or "error" in y:
+                    speed.append({"batch_size": bs, "legacy_error": x.get("error"), "current_error": y.get("error")})
+                else:
+                    speed.append({
+                        "batch_size": bs,
+                        "legacy_docs_per_second": x["docs_per_second"],
+                        "current_docs_per_second": y["docs_per_second"],
+                        "speedup": x["median_seconds"] / y["median_seconds"],
+                        "legacy_peak_allocated_mb": x.get("peak_allocated_mb"),
+                        "current_peak_allocated_mb": y.get("peak_allocated_mb"),
+                    })
+            quality = []
+            aq = {str(x.get("threshold")): x for x in at["quality"]}
+            bq = {str(x.get("threshold")): x for x in bt["quality"]}
+            for k in aq.keys() & bq.keys():
+                x, y = aq[k], bq[k]
+                if "error" in x or "error" in y:
+                    quality.append({"threshold": x.get("threshold"), "legacy_error": x.get("error"), "current_error": y.get("error")})
+                else:
+                    quality.append({"threshold": x.get("threshold"), **compare_signature(x, y)})
+            quality.sort(key=lambda x: -1 if x.get("threshold") is None else float(x["threshold"]))
+            cfg["tasks"][task] = {"speed_scope": at["speed_scope"], "speed": speed, "quality": quality}
+
+        if "training" in a and "training" in b:
+            train = []
+            aa, bb = rows_by_bs(a["training"]), rows_by_bs(b["training"])
+            for bs in sorted(set(aa) & set(bb)):
+                x, y = aa[bs], bb[bs]
+                if "error" in x or "error" in y:
+                    train.append({"batch_size": bs, "legacy_error": x.get("error"), "current_error": y.get("error")})
+                else:
+                    keys = set(x["deterministic_eval_loss"]) | set(y["deterministic_eval_loss"])
+                    legacy_peak = x.get("peak_allocated_mb")
+                    current_peak = y.get("peak_allocated_mb")
+                    train.append({
+                        "batch_size": bs,
+                        "legacy_samples_per_second": x["samples_per_second"],
+                        "current_samples_per_second": y["samples_per_second"],
+                        "speedup": x["median_seconds"] / y["median_seconds"],
+                        "legacy_peak_allocated_mb": legacy_peak,
+                        "current_peak_allocated_mb": current_peak,
+                        "memory_ratio_legacy_over_current": (
+                            legacy_peak / current_peak
+                            if legacy_peak is not None and current_peak not in (None, 0)
+                            else None
+                        ),
+                        "training_batch_seed": x.get("training_batch_seed"),
+                        "loss_abs_diff": {k: abs(x["deterministic_eval_loss"].get(k, 0.0) - y["deterministic_eval_loss"].get(k, 0.0)) for k in keys},
+                    })
+            cfg["training"] = train
+        out["configs"].append(cfg)
+    return out
+
+
+def print_comparison(data: Dict[str, Any]) -> None:
+    for cfg in data["configs"]:
+        print("\n" + "#" * 92)
+        print(f"device={cfg['device']} dtype={cfg['dtype']}")
+        print("#" * 92)
+        if "error" in cfg:
+            print(cfg["error"])
+            continue
+
+        if cfg.get("scaling"):
+            print("\nCONTROLLED TOKEN x QUERY SCALING")
+            print(" Tokens | Queries | B | legacy docs/s | current docs/s | speedup")
+            print("-" * 72)
+            for r in cfg["scaling"]:
+                if "legacy_error" in r or "current_error" in r:
+                    print(
+                        f"{r['tokens']:7d} | {r['queries']:7d} | {r['batch_size']:1d} | "
+                        f"ERROR legacy={r.get('legacy_error')} current={r.get('current_error')}"
+                    )
+                else:
+                    print(
+                        f"{r['tokens']:7d} | {r['queries']:7d} | {r['batch_size']:1d} | "
+                        f"{r['legacy_docs_per_second']:13.2f} | "
+                        f"{r['current_docs_per_second']:14.2f} | "
+                        f"{r['speedup']:7.3f}x"
+                    )
+
+        for task, result in cfg["tasks"].items():
+            suffix = " (batch_score)" if result["speed_scope"] == "joint_batch_score" else ""
+            print(f"\n{task.upper()} SPEED{suffix}")
+            print(" BS | legacy docs/s | current docs/s | speedup | legacy/current peak MB")
+            for r in result["speed"]:
+                if "legacy_error" in r or "current_error" in r:
+                    print(f"{r['batch_size']:3d} | ERROR legacy={r.get('legacy_error')} current={r.get('current_error')}")
+                    continue
+                lm, cm = r.get("legacy_peak_allocated_mb"), r.get("current_peak_allocated_mb")
+                mem = "-" if lm is None or cm is None else f"{lm:.0f}/{cm:.0f}"
+                print(f"{r['batch_size']:3d} | {r['legacy_docs_per_second']:13.2f} | {r['current_docs_per_second']:14.2f} | {r['speedup']:7.3f}x | {mem}")
+            print(f"{task.upper()} PARITY")
+            for q in result["quality"]:
+                if "legacy_error" in q or "current_error" in q:
+                    print(f"  {q.get('threshold')}: ERROR")
+                else:
+                    label = "joint" if q.get("threshold") is None else f"th={q['threshold']:.1f}"
+                    print(f"  {label}: match={q['match_rate']:.6f} conf_max={q['confidence_max_abs']:.3g}")
+        if "training" in cfg:
+            print("\nTRAINING FORWARD+BACKWARD")
+            print(" BS | legacy samp/s | current samp/s | speedup | legacy MB | current MB | mem ratio | max eval-loss diff")
+            for r in cfg["training"]:
+                if "legacy_error" in r or "current_error" in r:
+                    print(f"{r['batch_size']:3d} | ERROR")
+                else:
+                    md = max(r["loss_abs_diff"].values(), default=0.0)
+                    lm = r.get("legacy_peak_allocated_mb")
+                    cm = r.get("current_peak_allocated_mb")
+                    mr = r.get("memory_ratio_legacy_over_current")
+                    lm_s = f"{lm:.1f}" if lm is not None else "n/a"
+                    cm_s = f"{cm:.1f}" if cm is not None else "n/a"
+                    mr_s = f"{mr:.3f}x" if mr is not None else "n/a"
+                    print(
+                        f"{r['batch_size']:3d} | {r['legacy_samples_per_second']:13.2f} | "
+                        f"{r['current_samples_per_second']:14.2f} | {r['speedup']:7.3f}x | "
+                        f"{lm_s:>9} | {cm_s:>10} | {mr_s:>9} | {md:.3g}"
+                    )
+
+
+def parent(args: argparse.Namespace) -> int:
+    repo = repo_root()
+    tasks = csv(args.tasks)
+    bad = set(tasks) - set(TASKS)
+    if bad:
+        raise ValueError(f"unknown tasks: {sorted(bad)}")
+
+    texts = load_corpus(args.corpus_file, args.docs) if args.corpus_file else generate_corpus(
+        args.model, args.docs, csv_int(args.generated_lengths), args.seed
+    )
+    if not texts:
+        raise ValueError("empty corpus")
+
+    scaling_lengths = csv_int(args.scaling_token_lengths)
+    scaling_queries = csv_int(args.scaling_query_counts)
+    scaling_corpora = {}
+    if not args.no_scaling:
+        for length in scaling_lengths:
+            if length <= 0:
+                raise ValueError("scaling token lengths must be positive")
+            scaling_corpora[length] = generate_exact_token_corpus(
+                args.model,
+                args.scaling_docs,
+                length,
+                args.seed + 10000 + length,
+            )
+    if any(q <= 0 for q in scaling_queries):
+        raise ValueError("scaling query counts must be positive")
+
+    cfg = {
+        "model": args.model,
+        "seed": args.seed,
+        "devices": csv(args.devices),
+        "dtypes": csv(args.dtypes),
+        "tasks": tasks,
+        "batch_sizes": csv_int(args.batch_sizes),
+        "scaling": not args.no_scaling,
+        "scaling_token_lengths": scaling_lengths,
+        "scaling_query_counts": scaling_queries,
+        "scaling_docs": args.scaling_docs,
+        "repeats": args.repeats,
+        "warmup_docs": args.warmup_docs,
+        "speed_threshold": args.speed_threshold,
+        "thresholds": csv_float(args.thresholds),
+        "quality_docs": args.quality_docs,
+        "joint_quality_docs": args.joint_quality_docs,
+        "quality_batch_size": args.quality_batch_size,
+        "max_len": args.max_len,
+        "training": not args.no_training,
+        "training_batch_sizes": csv_int(args.training_batch_sizes),
+        "training_repeats": args.training_repeats,
+        "training_warmup": args.training_warmup,
+    }
+
+    print("=" * 88)
+    print("GLiNER2 EXACT LEGACY vs CURRENT DIRECT-SPAN BENCHMARK")
+    print(f"version:       {VERSION}")
+    print(f"repo:          {repo}")
+    print(f"legacy commit: {args.legacy_commit}")
+    print(f"current kernel:{CURRENT_DIRECT_KERNEL:>16}")
+    print(f"documents:     {len(texts)}")
+    print(f"tasks:         {tasks}")
+    print(f"batch sizes:   {cfg['batch_sizes']} (secondary axis)")
+    if cfg["scaling"]:
+        print(
+            f"PRIMARY GRID:  tokens={cfg['scaling_token_lengths']} "
+            f"queries={cfg['scaling_query_counts']} "
+            f"docs/length={cfg['scaling_docs']}"
+        )
+    print(f"logical CPUs:  {os.cpu_count() or 1}")
+    ctot, ccompute, cworkers = cpu_plan("cpu")
+    gtot, gcompute, gworkers = cpu_plan("cuda")
+    print(f"CPU policy:    {ccompute} compute + {cworkers} preprocess workers (75/25)")
+    print(f"CUDA policy:   {gcompute} host compute + {gworkers} preprocess workers")
+    print("Joint speed:   batch_score only; full decode is parity-only")
+    print("training:      CUDA only")
+    print("=" * 88)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    script = Path(__file__).resolve()
+    with tempfile.TemporaryDirectory(prefix="gliner2_legacy_") as td:
+        td = Path(td)
+        legacy_repo = td / "legacy"
+        export_commit(repo, args.legacy_commit, legacy_repo)
+        cfg_file, corpus_file = td / "config.json", td / "corpus.json"
+        legacy_file, current_file = td / "legacy.json", td / "current.json"
+        cfg_file.write_text(json.dumps(cfg))
+        corpus_file.write_text(json.dumps({
+            "main": texts,
+            "scaling": {str(k): v for k, v in scaling_corpora.items()},
+        }))
+        launch(script, legacy_repo, "legacy", cfg_file, corpus_file, legacy_file)
+        launch(script, repo, "current", cfg_file, corpus_file, current_file)
+        legacy = json.loads(legacy_file.read_text())
+        current = json.loads(current_file.read_text())
+        if legacy["corpus_sha256"] != current["corpus_sha256"]:
+            raise RuntimeError("legacy/current corpus mismatch")
+        if legacy.get("scaling_corpus_sha256") != current.get("scaling_corpus_sha256"):
+            raise RuntimeError("legacy/current scaling corpus mismatch")
+        comparison = compare(legacy, current)
+        final = {
+            "metadata": {
+                "version": VERSION,
+                "legacy_commit": args.legacy_commit,
+                "current_direct_kernel": CURRENT_DIRECT_KERNEL,
+                "training_rng_policy": "seed Python/NumPy/PyTorch/CUDA before batch construction and each forward+backward, outside timed region",
+                "subprocess_pythonhashseed": cfg["seed"],
+                "current_head": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo, text=True).strip(),
+                "current_dirty": bool(subprocess.check_output(["git", "status", "--porcelain"], cwd=repo, text=True).strip()),
+                "corpus_sha256": corpus_hash(texts),
+                "scaling_corpus_sha256": {
+                    str(k): corpus_hash(v) for k, v in sorted(scaling_corpora.items())
+                },
+                "config": cfg,
+            },
+            "comparison": comparison,
+            "legacy": legacy,
+            "current": current,
+        }
+        args.output.write_text(json.dumps(final, indent=2))
+
+    print_comparison(comparison)
+    print(f"\nFull JSON: {args.output}")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument("--model", default="fastino/gliner2-base-v1")
+    p.add_argument("--legacy-commit", default=LEGACY_COMMIT)
+    p.add_argument("--docs", type=int, default=128)
+    p.add_argument("--corpus-file", type=Path)
+    p.add_argument("--generated-lengths", default="64,128,256,384")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--tasks", default=",".join(TASKS))
+    p.add_argument("--batch-sizes", default="1,8", help="secondary batch-size axis; L x Q is the primary scaling experiment")
+    p.add_argument("--devices", default="auto", help="auto or cpu,cuda")
+    p.add_argument("--dtypes", default="auto", help="auto or fp32,fp16,bf16")
+    p.add_argument("--scaling-token-lengths", default="64,256", help="primary L axis")
+    p.add_argument("--scaling-query-counts", default="1,8,32", help="primary Q axis")
+    p.add_argument("--scaling-docs", type=int, default=128, help="documents per token-length point")
+    p.add_argument("--no-scaling", action="store_true", help="disable the controlled L x Q benchmark")
+    p.add_argument("--repeats", type=int, default=3)
+    p.add_argument("--warmup-docs", type=int, default=16)
+    p.add_argument("--speed-threshold", type=float, default=0.5)
+    p.add_argument("--thresholds", default="0.1,0.3,0.5,0.7,0.9")
+    p.add_argument("--quality-docs", type=int, default=64)
+    p.add_argument("--joint-quality-docs", type=int, default=16)
+    p.add_argument("--quality-batch-size", type=int, default=0, help="0 = largest successful speed batch")
+    p.add_argument("--max-len", type=int, default=512)
+    p.add_argument("--no-training", action="store_true")
+    p.add_argument("--training-batch-sizes", default="1,8")
+    p.add_argument("--training-repeats", type=int, default=3)
+    p.add_argument("--training-warmup", type=int, default=1)
+    p.add_argument("--output", type=Path, default=Path("benchmarks/direct_span_exact_legacy_results.json"))
+    p.add_argument("--_worker", action="store_true", help=argparse.SUPPRESS)
+    p.add_argument("--_repo", type=Path, help=argparse.SUPPRESS)
+    p.add_argument("--_variant", choices=["legacy", "current"], help=argparse.SUPPRESS)
+    p.add_argument("--_config", type=Path, help=argparse.SUPPRESS)
+    p.add_argument("--_corpus", type=Path, help=argparse.SUPPRESS)
+    p.add_argument("--_worker-output", type=Path, help=argparse.SUPPRESS)
+    return p
+
+
+def main() -> int:
+    args = parser().parse_args()
+    if args._worker:
+        return worker(args._repo, args._variant, args._config, args._corpus, args._worker_output)
+    return parent(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/gliner2/inference/runtime.py
+++ b/gliner2/inference/runtime.py
@@ -225,21 +225,14 @@ class ExtractorRuntimeMixin:
             batch
         )
 
-        span_samples = []
-        for i in range(len(batch)):
-            has_span = any(t != "classifications" for t in batch.task_types[i])
-            if has_span and all_token_embs[i].numel() > 0:
-                span_samples.append(i)
-
-        all_span_info = [None] * len(batch)
-        if span_samples:
-            span_embs = [all_token_embs[i] for i in span_samples]
-            span_results = self.compute_span_rep_batched(span_embs)
-            for idx, si in zip(span_samples, span_results):
-                all_span_info[idx] = si
+        # Build every span task's count-aware query vectors first, concatenate
+        # them per sample, then run one factorized span-scoring pass per model
+        # batch.  Classification tasks do not participate in span scoring.
+        all_raw_logits, all_pred_counts = self._compute_direct_span_logits_batched(
+            batch, all_token_embs, all_schema_embs
+        )
 
         results = []
-
         for i in range(len(batch)):
             try:
                 sample_result = self._extract_sample(
@@ -256,7 +249,8 @@ class ExtractorRuntimeMixin:
                     metadata=metadata_list[i],
                     include_confidence=include_confidence,
                     include_spans=include_spans,
-                    span_info=all_span_info[i],
+                    raw_span_logits=all_raw_logits[i],
+                    pred_counts=all_pred_counts[i],
                 )
                 results.append(sample_result)
             except Exception:
@@ -266,6 +260,106 @@ class ExtractorRuntimeMixin:
                 results.append({})
 
         return results
+
+    def _compute_direct_span_logits_batched(
+        self,
+        batch: PreprocessedBatch,
+        all_token_embs: List[torch.Tensor],
+        all_schema_embs: List[List[List[torch.Tensor]]],
+    ) -> Tuple[List[List[Optional[torch.Tensor]]], List[List[int]]]:
+        """Compute direct logits for every non-classification schema in a batch.
+
+        Query vectors from all span tasks belonging to the same sample are
+        concatenated so token-side span projections are computed only once.
+        Returned logits are restored to the legacy ``[count, fields, L, W]``
+        layout expected by the decoders.
+        """
+        batch_size = len(batch)
+        raw_logits: List[List[Optional[torch.Tensor]]] = [
+            [None] * len(batch.task_types[i]) for i in range(batch_size)
+        ]
+        pred_counts: List[List[int]] = [
+            [0] * len(batch.task_types[i]) for i in range(batch_size)
+        ]
+
+        # Batch the count head across every span task to avoid per-schema device
+        # synchronizations while preserving the same pointwise count network.
+        count_records = []
+        count_inputs = []
+        for sample_idx in range(batch_size):
+            if all_token_embs[sample_idx].numel() == 0:
+                continue
+            for task_idx, task_type in enumerate(batch.task_types[sample_idx]):
+                if task_type == "classifications":
+                    continue
+                if task_idx >= len(all_schema_embs[sample_idx]):
+                    continue
+                schema_emb_list = all_schema_embs[sample_idx][task_idx]
+                schema_tokens = batch.schema_tokens_list[sample_idx][task_idx]
+                if not schema_emb_list or len(schema_tokens) < 4:
+                    continue
+                if not any(
+                    schema_tokens[j] in ("[E]", "[C]", "[R]")
+                    for j in range(len(schema_tokens) - 1)
+                ):
+                    continue
+
+                embs = torch.stack(schema_emb_list)
+                count_records.append((sample_idx, task_idx, embs))
+                count_inputs.append(embs[0])
+
+        if count_inputs:
+            counts = self.count_pred(torch.stack(count_inputs)).argmax(dim=-1).tolist()
+        else:
+            counts = []
+
+        # Build count-aware structural queries and concatenate them by sample.
+        query_chunks: List[List[torch.Tensor]] = [[] for _ in range(batch_size)]
+        query_slices: Dict[Tuple[int, int], Tuple[int, int, int, int]] = {}
+        query_offsets = [0] * batch_size
+
+        for (sample_idx, task_idx, embs), pred_count in zip(count_records, counts):
+            pred_count = int(pred_count)
+            pred_counts[sample_idx][task_idx] = pred_count
+            if pred_count <= 0:
+                continue
+
+            struct_proj = self.count_embed(embs[1:], pred_count)
+            if struct_proj.numel() == 0:
+                continue
+
+            # Entity decoding consumes only structural instance 0.
+            if batch.task_types[sample_idx][task_idx] == "entities":
+                struct_proj = struct_proj[:1]
+
+            count_dim, field_dim, hidden = struct_proj.shape
+            flat_queries = struct_proj.reshape(count_dim * field_dim, hidden)
+            start = query_offsets[sample_idx]
+            stop = start + flat_queries.shape[0]
+            query_offsets[sample_idx] = stop
+            query_chunks[sample_idx].append(flat_queries)
+            query_slices[(sample_idx, task_idx)] = (
+                start, stop, count_dim, field_dim
+            )
+
+        active_indices = [i for i, chunks in enumerate(query_chunks) if chunks]
+        if not active_indices:
+            return raw_logits, pred_counts
+
+        active_tokens = [all_token_embs[i] for i in active_indices]
+        active_queries = [torch.cat(query_chunks[i], dim=0) for i in active_indices]
+        direct_logits = self.compute_span_scores_batched(
+            active_tokens, active_queries, mask_invalid=True
+        )
+
+        logits_by_sample = dict(zip(active_indices, direct_logits))
+        for (sample_idx, task_idx), (start, stop, count_dim, field_dim) in query_slices.items():
+            task_logits = logits_by_sample[sample_idx][start:stop]
+            raw_logits[sample_idx][task_idx] = task_logits.reshape(
+                count_dim, field_dim, task_logits.shape[-2], task_logits.shape[-1]
+            )
+
+        return raw_logits, pred_counts
 
     def _extract_sample(
         self,
@@ -282,15 +376,13 @@ class ExtractorRuntimeMixin:
         metadata: Dict,
         include_confidence: bool,
         include_spans: bool,
-        span_info: Optional[Dict] = None,
+        raw_span_logits: Optional[List[Optional[torch.Tensor]]] = None,
+        pred_counts: Optional[List[int]] = None,
     ) -> Dict[str, Any]:
-        """Extract from single sample."""
+        """Extract from single sample using precomputed direct span logits."""
         results = {}
-
-        if span_info is None:
-            has_span_task = any(t != "classifications" for t in task_types)
-            if has_span_task and token_embs.numel() > 0:
-                span_info = self.compute_span_rep(token_embs)
+        raw_span_logits = raw_span_logits or [None] * len(task_types)
+        pred_counts = pred_counts or [0] * len(task_types)
 
         cls_fields = {}
         for struct in schema.get("json_structures", []):
@@ -314,10 +406,10 @@ class ExtractorRuntimeMixin:
                 )
             else:
                 self._extract_span_result(
-                    results, schema_name, task_type, embs, span_info,
-                    schema_tokens, text_tokens, text_len, original_text,
-                    start_mapping, end_mapping, threshold, metadata,
-                    cls_fields, include_confidence, include_spans,
+                    results, schema_name, task_type, raw_span_logits[i],
+                    pred_counts[i], schema_tokens, text_tokens, text_len,
+                    original_text, start_mapping, end_mapping, threshold,
+                    metadata, cls_fields, include_confidence, include_spans,
                 )
 
         return results
@@ -393,8 +485,8 @@ class ExtractorRuntimeMixin:
         results: Dict,
         schema_name: str,
         task_type: str,
-        embs: torch.Tensor,
-        span_info: Dict,
+        raw_logits: Optional[torch.Tensor],
+        pred_count: int,
         schema_tokens: List[str],
         text_tokens: List[str],
         text_len: int,
@@ -407,7 +499,7 @@ class ExtractorRuntimeMixin:
         include_confidence: bool,
         include_spans: bool,
     ):
-        """Extract span-based results."""
+        """Decode precomputed direct span logits for one schema task."""
         field_names = []
         for j in range(len(schema_tokens) - 1):
             if schema_tokens[j] in ("[E]", "[C]", "[R]"):
@@ -417,10 +509,7 @@ class ExtractorRuntimeMixin:
             results[schema_name] = [] if schema_name == "entities" else {}
             return
 
-        count_logits = self.count_pred(embs[0].unsqueeze(0))
-        pred_count = int(count_logits.argmax(dim=1).item())
-
-        if pred_count <= 0 or span_info is None:
+        if pred_count <= 0 or raw_logits is None:
             if schema_name == "entities":
                 results[schema_name] = []
             elif task_type == "relations":
@@ -429,10 +518,6 @@ class ExtractorRuntimeMixin:
                 results[schema_name] = {}
             return
 
-        struct_proj = self.count_embed(embs[1:], pred_count)
-        raw_logits = torch.einsum(
-            "lkd,bpd->bplk", span_info["span_rep"], struct_proj
-        )
         span_scores = torch.sigmoid(raw_logits)
 
         if schema_name == "entities":

--- a/gliner2/joint_ie/scoring.py
+++ b/gliner2/joint_ie/scoring.py
@@ -245,15 +245,14 @@ class RawScorer:
             token_embs, schema_embs = self.processor.extract_embeddings_from_batch(
                 encoded, batch.input_ids, batch
             )
-            span_infos = self.model.compute_span_rep_batched(token_embs)
             for local_index, caller_text in enumerate(chunk_texts):
                 results.append(self._build_lattice(
                     caller_text,
                     schema_list[offset + local_index],
                     batch,
                     local_index,
+                    token_embs[local_index],
                     schema_embs[local_index],
-                    span_infos[local_index],
                     count_top_k,
                 ))
         return results
@@ -264,8 +263,8 @@ class RawScorer:
         original_schema: Any,
         batch: Any,
         index: int,
+        token_emb: torch.Tensor,
         schema_embs: Sequence[Sequence[torch.Tensor]],
-        span_info: Mapping[str, torch.Tensor],
         count_top_k: int,
     ) -> ScoreLattice:
         starts_all = list(batch.start_mappings[index])
@@ -273,28 +272,34 @@ class RawScorer:
 
         # collate_fn_inference may append punctuation.  Start mappings at or past
         # len(caller_text) describe that synthetic suffix, so they are excluded.
-        # Keeping this rule tied to starts (rather than token text) also handles a
-        # caller whose final character is itself punctuation.
         caller_token_count = len(starts_all)
         while caller_token_count and starts_all[caller_token_count - 1] >= len(caller_text):
             caller_token_count -= 1
         starts = starts_all[:caller_token_count]
         ends = ends_all[:caller_token_count]
 
-        dense_rep = span_info["span_rep"]
         all_token_count = len(starts_all)
-        document_start = max(0, dense_rep.shape[0] - all_token_count)
-        dense_rep = dense_rep[document_start:document_start + caller_token_count]
-        length, width = dense_rep.shape[:2]
-        row = torch.arange(length, device=dense_rep.device).unsqueeze(1)
-        col = torch.arange(width, device=dense_rep.device).unsqueeze(0)
+        document_start = max(0, token_emb.shape[0] - all_token_count)
+        document_tokens = token_emb[
+            document_start:document_start + caller_token_count
+        ]
+        length = document_tokens.shape[0]
+        width = self.model.max_width
+        row = torch.arange(length, device=document_tokens.device).unsqueeze(1)
+        col = torch.arange(width, device=document_tokens.device).unsqueeze(0)
         dense_ends = row + col
         valid = dense_ends < caller_token_count
         span_starts = row.expand(length, width)
 
-        tasks: List[TaskLattice] = []
+        # First construct every task/count hypothesis and its count-aware query
+        # vectors.  All non-empty queries are concatenated so the token-side
+        # factorized span computation runs once for the whole document.
+        task_specs = []
+        query_chunks = []
+        query_offset = 0
         task_types = batch.task_types[index]
         token_schemas = batch.schema_tokens_list[index]
+
         for task_index, (tokens, task_type, embeddings) in enumerate(
             zip(token_schemas, task_types, schema_embs)
         ):
@@ -310,20 +315,60 @@ class RawScorer:
                 k = min(count_top_k, count_logits.numel())
                 values, indices = torch.topk(probabilities, k=k)
                 hypotheses = [
-                    (int(count), float(torch.logit(prob.clamp(1e-7, 1 - 1e-7)).detach().cpu()), float(prob.detach().cpu()))
+                    (
+                        int(count),
+                        float(torch.logit(prob.clamp(1e-7, 1 - 1e-7)).detach().cpu()),
+                        float(prob.detach().cpu()),
+                    )
                     for prob, count in zip(values, indices)
                 ]
 
-            count_scores: List[CountHypothesis] = []
+            hypothesis_specs = []
             for count, count_logit, count_probability in hypotheses:
                 if count <= 0:
-                    role_logits = dense_rep.new_empty((0, len(fields), length, width))
+                    hypothesis_specs.append((
+                        count, count_logit, count_probability, None, 0, 0
+                    ))
+                    continue
+
+                projected = self.model.count_embed(embs[1:], count)
+                slots, roles, hidden = projected.shape
+                flat = projected.reshape(slots * roles, hidden)
+                start = query_offset
+                stop = start + flat.shape[0]
+                query_offset = stop
+                query_chunks.append(flat)
+                hypothesis_specs.append((
+                    count, count_logit, count_probability,
+                    (start, stop), slots, roles
+                ))
+
+            task_specs.append((
+                task_index, tokens, task_type, fields, hypothesis_specs
+            ))
+
+        direct_logits = None
+        if query_chunks and length > 0:
+            queries = torch.cat(query_chunks, dim=0).unsqueeze(0)
+            direct_logits = self.model.span_rep.score_queries(
+                document_tokens.unsqueeze(0), queries, mask_invalid=True
+            )[0]
+
+        tasks: List[TaskLattice] = []
+        for task_index, tokens, task_type, fields, hypothesis_specs in task_specs:
+            count_scores: List[CountHypothesis] = []
+            for (
+                count, count_logit, count_probability, query_slice, slots, roles
+            ) in hypothesis_specs:
+                if count <= 0 or query_slice is None:
+                    role_logits = document_tokens.new_empty(
+                        (0, len(fields), length, width)
+                    )
                 else:
-                    projected = self.model.count_embed(embs[1:], count)
-                    role_logits = torch.einsum("lkd,bpd->bplk", dense_rep, projected)
-                    # Preserve the dense shape but make synthetic/padded spans
-                    # impossible for downstream optimizers to select.
-                    role_logits = role_logits.masked_fill(~valid.unsqueeze(0).unsqueeze(0), -torch.inf)
+                    start, stop = query_slice
+                    role_logits = direct_logits[start:stop].reshape(
+                        slots, roles, length, width
+                    )
                 count_scores.append(CountHypothesis(
                     count=count,
                     logit=count_logit,
@@ -331,6 +376,7 @@ class RawScorer:
                     role_logits=role_logits,
                     role_probabilities=torch.sigmoid(role_logits),
                 ))
+
             tasks.append(TaskLattice(
                 name=_task_name(tokens, f"task_{task_index}"),
                 task_type=task_type,

--- a/gliner2/layers.py
+++ b/gliner2/layers.py
@@ -399,6 +399,100 @@ class SpanMarkerV0(nn.Module):
 
         return self.out_project(cat).view(B, L, self.max_width, D)
 
+    def score_queries(
+        self,
+        h: torch.Tensor,
+        queries: torch.Tensor,
+        text_lengths: Optional[torch.Tensor] = None,
+        *,
+        mask_invalid: bool = True,
+    ) -> torch.Tensor:
+        """Score spans directly against query vectors without final span materialization.
+
+        For valid spans this is algebraically equivalent to ``forward()``
+        followed by a dot product with ``queries``.  The first layer of
+        ``out_project`` is split
+        into start/end halves and the final layer is folded into the queries.
+
+        Dropout remains in the same locations as the legacy path, so this
+        factorization is valid in training as well as inference.  Set
+        ``mask_invalid=False`` when the caller applies the legacy span mask
+        after computing a loss; using ``-inf`` logits before BCE can otherwise
+        produce ``inf * 0 -> nan``.  Invalid unmasked entries are finite padding
+        values and are intentionally ignored by that post-loss validity mask.
+
+        Args:
+            h: Token representations ``[B, L, H]``.
+            queries: Query vectors ``[B, Q, H]``.
+            text_lengths: Optional true sequence lengths ``[B]`` for padded input.
+            mask_invalid: Fill invalid spans with ``-inf`` when True.
+
+        Returns:
+            Raw span logits ``[B, Q, L, max_width]``.
+        """
+        B, L, H = h.shape
+        if queries.ndim != 3 or queries.shape[0] != B or queries.shape[-1] != H:
+            raise ValueError(
+                "queries must have shape [batch, num_queries, hidden_size]"
+            )
+
+        first_linear = self.out_project[0]   # 2H -> 4H
+        dropout = self.out_project[2]        # same module/location as legacy
+        final_linear = self.out_project[3]   # 4H -> H
+
+        # Legacy computes ReLU(cat(start_rep, end_rep)).  ReLU is elementwise
+        start_rep = self.project_start(h).relu()
+        end_rep = self.project_end(h).relu()
+
+        # Split W1 = [W_start | W_end].  These large projections are now done
+        # once per token rather than once per candidate span.
+        start_hidden = F.linear(start_rep, first_linear.weight[:, :H], None)
+        end_hidden = F.linear(end_rep, first_linear.weight[:, H:], None)
+
+        starts = torch.arange(L, device=h.device).unsqueeze(1)
+        widths = torch.arange(self.max_width, device=h.device).unsqueeze(0)
+        ends = starts + widths
+
+        valid = (ends < L).unsqueeze(0).expand(B, -1, -1)
+        if text_lengths is not None:
+            valid = valid & (ends.unsqueeze(0) < text_lengths[:, None, None])
+
+        # Consecutive span ends are sliding windows over end_hidden.  Padding by
+        # max_width - 1 and unfolding creates a strided view instead of two
+        # [B, L, W, 4H] advanced-indexing gathers.  The start contribution stays
+        # [B, L, 1, 4H] and broadcasts across widths.
+        end_padded = F.pad(
+            end_hidden, (0, 0, 0, self.max_width - 1)
+        )
+        end_windows = end_padded.unfold(1, self.max_width, 1).permute(0, 1, 3, 2)
+        hidden = start_hidden.unsqueeze(2) + end_windows
+        if first_linear.bias is not None:
+            hidden = hidden + first_linear.bias
+        hidden = hidden.relu()
+
+        # Preserve the legacy dropout placement and flattened element order.
+        # Keeping this flattened also feeds baddbmm directly without reshaping
+        # back to [B, L, W, 4H].
+        hidden = dropout(hidden.reshape(B, L * self.max_width, -1))
+
+        # q^T(W2 d + b2) = (q^T W2)d + q^T b2
+        folded_queries = torch.matmul(queries, final_linear.weight)
+        folded_queries_t = folded_queries.transpose(1, 2)
+        if final_linear.bias is not None:
+            query_bias = torch.matmul(queries, final_linear.bias)
+            logits = torch.baddbmm(
+                query_bias[:, None, :], hidden, folded_queries_t
+            )
+        else:
+            logits = torch.bmm(hidden, folded_queries_t)
+        logits = logits.transpose(1, 2).reshape(
+            B, queries.shape[1], L, self.max_width
+        )
+
+        if mask_invalid:
+            logits = logits.masked_fill(~valid[:, None, :, :], float("-inf"))
+        return logits
+
 
 class SpanRepLayer(nn.Module):
     """Factory class for various span representation approaches.
@@ -442,3 +536,16 @@ class SpanRepLayer(nn.Module):
                 [B, L, max_width, D].
         """
         return self.span_rep_layer(x, *args)
+
+    def score_queries(
+        self,
+        x: torch.Tensor,
+        queries: torch.Tensor,
+        text_lengths: Optional[torch.Tensor] = None,
+        *,
+        mask_invalid: bool = True,
+    ) -> torch.Tensor:
+        """Direct factorized span scoring for ``markerV0``."""
+        return self.span_rep_layer.score_queries(
+            x, queries, text_lengths, mask_invalid=mask_invalid
+        )

--- a/gliner2/models/span/model.py
+++ b/gliner2/models/span/model.py
@@ -184,19 +184,16 @@ class SpanExtractorModel(BaseExtractorModel):
         # Encode batch through transformer
         all_token_embs, all_schema_embs = self._encode_batch(batch)
 
-        # Batch span rep for samples that need it
-        span_samples = []
-        for i in range(len(batch)):
-            has_span = any(t != "classifications" for t in batch.task_types[i])
-            if has_span and all_token_embs[i].numel() > 0:
-                span_samples.append(i)
-
-        all_span_info = [None] * len(batch)
-        if span_samples:
-            span_embs = [all_token_embs[i] for i in span_samples]
-            span_results = self.compute_span_rep_batched(span_embs)
-            for idx, si in zip(span_samples, span_results):
-                all_span_info[idx] = si
+        # Build count-aware structural queries for every span task, concatenate
+        # them per sample, and score them directly without materializing
+        # [B, L, W, H] span representations.  ``mask_invalid=False`` keeps BCE
+        # inputs finite; the loss applies the legacy validity mask afterwards.
+        all_span_scores = self._compute_training_span_scores_batched(
+            all_token_embs,
+            all_schema_embs,
+            batch.task_types,
+            batch.structure_labels,
+        )
 
         # Compute losses for each sample
         cls_losses = []
@@ -213,7 +210,7 @@ class SpanExtractorModel(BaseExtractorModel):
                     task_types=batch.task_types[i],
                     structure_labels=batch.structure_labels[i],
                     device=device,
-                    span_info=all_span_info[i]
+                    span_scores_per_schema=all_span_scores[i]
                 )
 
                 cls_losses.append(sample_losses["classification"])
@@ -329,32 +326,13 @@ class SpanExtractorModel(BaseExtractorModel):
             task_types: List[str],
             structure_labels: List[Any],
             device: torch.device,
-            span_info: Optional[Dict[str, Any]] = None
+            span_scores_per_schema: Optional[List[Optional[torch.Tensor]]] = None
     ) -> Dict[str, torch.Tensor]:
-        """
-        Compute all losses for a single sample.
-
-        Args:
-            token_embeddings: (text_len, hidden) text token embeddings
-            embs_per_schema: List of schema embeddings
-            task_types: Task type for each schema
-            structure_labels: Labels for each schema
-            device: Computation device
-            span_info: Pre-computed span representations (from batched computation).
-                       If None, computed on-the-fly for this sample.
-
-        Returns:
-            Dict with classification, structure, and count losses
-        """
+        """Compute all losses for a single sample from direct span logits."""
         cls_loss = torch.tensor(0.0, device=device)
         struct_loss = torch.tensor(0.0, device=device)
         count_loss = torch.tensor(0.0, device=device)
-
-        # Compute span representations if needed and not pre-computed
-        if span_info is None:
-            has_span_task = any(t != "classifications" for t in task_types)
-            if has_span_task and token_embeddings.numel() > 0:
-                span_info = self.compute_span_rep(token_embeddings)
+        span_scores_per_schema = span_scores_per_schema or [None] * len(task_types)
 
         all_counts = []
         all_p_embs = []
@@ -366,7 +344,6 @@ class SpanExtractorModel(BaseExtractorModel):
             schema_emb = torch.stack(embs_per_schema[i])
 
             if task_type == "classifications":
-                # Classification loss
                 cls_embeds = schema_emb[1:]  # Skip [P] token
                 logits = self.classifier(cls_embeds).squeeze(-1)
                 labels = torch.tensor(structure_labels[i], dtype=torch.float, device=device)
@@ -374,27 +351,21 @@ class SpanExtractorModel(BaseExtractorModel):
                     logits, labels, reduction="sum"
                 )
             else:
-                # Structure loss
                 structure = structure_labels[i]
-
                 if structure[0] == 0:
-                    # No instances to extract
                     continue
 
-                if span_info is not None:
-                    struct_loss = struct_loss + self.compute_struct_loss(
-                        span_info["span_rep"],
-                        schema_emb,
-                        structure,
-                        span_info["span_mask"]
+                scores = span_scores_per_schema[i]
+                if scores is not None:
+                    struct_loss = struct_loss + self.compute_struct_loss_from_scores(
+                        scores, structure
                     )
 
-                # Collect for count loss (skip entities)
+                # Preserve legacy count-loss behavior (entities are skipped).
                 if task_type != "entities":
                     all_counts.append(min(structure[0], 19))
                     all_p_embs.append(schema_emb[0])
 
-        # Count loss
         if all_counts and all_p_embs:
             counts = torch.tensor(all_counts, dtype=torch.long, device=device)
             p_embs = torch.stack(all_p_embs)
@@ -405,6 +376,77 @@ class SpanExtractorModel(BaseExtractorModel):
             "structure": struct_loss,
             "count": count_loss
         }
+
+    def _compute_training_span_scores_batched(
+            self,
+            token_embs_list: List[torch.Tensor],
+            all_schema_embs: List[List[List[torch.Tensor]]],
+            all_task_types: List[List[str]],
+            all_structure_labels: List[List[Any]],
+    ) -> List[List[Optional[torch.Tensor]]]:
+        """Directly score all training span tasks with one token-side pass/sample.
+
+        Each schema's ``count_embed`` output is flattened to query vectors.
+        Queries from all span schemas in a sample are concatenated, passed once
+        through the factorized scorer, then restored to ``[count, fields, L, W]``.
+        """
+        batch_size = len(token_embs_list)
+        outputs: List[List[Optional[torch.Tensor]]] = [
+            [None] * len(all_task_types[i]) for i in range(batch_size)
+        ]
+        query_chunks: List[List[torch.Tensor]] = [[] for _ in range(batch_size)]
+        query_slices: Dict[Tuple[int, int], Tuple[int, int, int, int]] = {}
+        offsets = [0] * batch_size
+
+        for sample_idx in range(batch_size):
+            if token_embs_list[sample_idx].numel() == 0:
+                continue
+            for task_idx, task_type in enumerate(all_task_types[sample_idx]):
+                if task_type == "classifications":
+                    continue
+                if task_idx >= len(all_schema_embs[sample_idx]):
+                    continue
+                if not all_schema_embs[sample_idx][task_idx]:
+                    continue
+
+                structure = all_structure_labels[sample_idx][task_idx]
+                if structure[0] == 0:
+                    continue
+
+                schema_emb = torch.stack(all_schema_embs[sample_idx][task_idx])
+                gold_count = min(structure[0], 19)
+                struct_proj = self.count_embed(schema_emb[1:], gold_count)
+                if struct_proj.numel() == 0:
+                    continue
+
+                count_dim, field_dim, hidden = struct_proj.shape
+                flat_queries = struct_proj.reshape(count_dim * field_dim, hidden)
+                start = offsets[sample_idx]
+                stop = start + flat_queries.shape[0]
+                offsets[sample_idx] = stop
+                query_chunks[sample_idx].append(flat_queries)
+                query_slices[(sample_idx, task_idx)] = (
+                    start, stop, count_dim, field_dim
+                )
+
+        active_indices = [i for i, chunks in enumerate(query_chunks) if chunks]
+        if not active_indices:
+            return outputs
+
+        direct_scores = self.compute_span_scores_batched(
+            [token_embs_list[i] for i in active_indices],
+            [torch.cat(query_chunks[i], dim=0) for i in active_indices],
+            mask_invalid=False,
+        )
+        scores_by_sample = dict(zip(active_indices, direct_scores))
+
+        for (sample_idx, task_idx), (start, stop, count_dim, field_dim) in query_slices.items():
+            task_scores = scores_by_sample[sample_idx][start:stop]
+            outputs[sample_idx][task_idx] = task_scores.reshape(
+                count_dim, field_dim, task_scores.shape[-2], task_scores.shape[-1]
+            )
+
+        return outputs
 
     # =========================================================================
     # Span Representation
@@ -514,6 +556,59 @@ class SpanExtractorModel(BaseExtractorModel):
             })
         return results
 
+    def compute_span_scores_batched(
+            self,
+            token_embs_list: List[torch.Tensor],
+            query_embs_list: List[torch.Tensor],
+            *,
+            mask_invalid: bool = True,
+    ) -> List[torch.Tensor]:
+        """Score variable-length token batches directly against queries."""
+        if len(token_embs_list) != len(query_embs_list):
+            raise ValueError("token/query batch sizes must match")
+        if not token_embs_list:
+            return []
+
+        device = token_embs_list[0].device
+        dtype = token_embs_list[0].dtype
+        text_lengths = [len(t) for t in token_embs_list]
+        query_lengths = [len(q) for q in query_embs_list]
+        max_text_len = max(text_lengths)
+        max_queries = max(query_lengths, default=0)
+        batch_size = len(token_embs_list)
+        hidden = token_embs_list[0].shape[-1]
+
+        padded_tokens = torch.zeros(
+            batch_size, max_text_len, hidden, device=device, dtype=dtype
+        )
+        padded_queries = torch.zeros(
+            batch_size, max_queries, hidden, device=device, dtype=dtype
+        )
+        for i, (tokens, queries) in enumerate(zip(token_embs_list, query_embs_list)):
+            padded_tokens[i, :text_lengths[i]] = tokens
+            padded_queries[i, :query_lengths[i]] = queries
+
+        text_len_t = torch.tensor(text_lengths, device=device)
+        logits = self._compute_span_scores_core(
+            padded_tokens, padded_queries, text_len_t, mask_invalid
+        )
+        return [
+            logits[i, :query_lengths[i], :text_lengths[i], :]
+            for i in range(batch_size)
+        ]
+
+    def _compute_span_scores_core(
+            self,
+            padded: torch.Tensor,
+            queries: torch.Tensor,
+            text_len_t: torch.Tensor,
+            mask_invalid: bool = True,
+    ) -> torch.Tensor:
+        """Dense direct-score core kept separate for ``torch.compile``."""
+        return self.span_rep.score_queries(
+            padded, queries, text_len_t, mask_invalid=mask_invalid
+        )
+
     def _compute_span_rep_core(
             self,
             padded: torch.Tensor,
@@ -555,6 +650,56 @@ class SpanExtractorModel(BaseExtractorModel):
         span_rep = self.span_rep(padded, safe_spans)  # (batch, max_text_len, max_width, hidden)
 
         return span_rep, safe_spans, span_mask
+
+    def compute_struct_loss_from_scores(
+            self,
+            scores: torch.Tensor,
+            structure: List[Any],
+            masking_rate: float = 0.5
+    ) -> torch.Tensor:
+        """Compute the legacy structure loss from direct raw span logits."""
+        gold_count = min(structure[0], 19)
+        if scores.shape[0] != gold_count:
+            raise ValueError(
+                f"score count dimension {scores.shape[0]} != gold count {gold_count}"
+            )
+
+        labs = torch.zeros_like(scores)
+        for i in range(gold_count):
+            gold_spans = structure[1][i]
+            for k, span in enumerate(gold_spans):
+                if span is None or span == (-1, -1):
+                    continue
+                if isinstance(span, tuple):
+                    start, end = span
+                    width = end - start
+                    if 0 <= start < scores.shape[2] and 0 <= width < scores.shape[3]:
+                        labs[i, k, start, width] = 1
+                elif isinstance(span, list):
+                    for sub in span:
+                        if sub is None or sub == (-1, -1):
+                            continue
+                        start, end = sub
+                        width = end - start
+                        if 0 <= start < scores.shape[2] and 0 <= width < scores.shape[3]:
+                            labs[i, k, start, width] = 1
+
+        if masking_rate > 0.0 and self.training:
+            negative = (labs == 0)
+            random_mask = torch.rand_like(scores) < masking_rate
+            loss_mask = (~(negative & random_mask)).float()
+        else:
+            loss_mask = torch.ones_like(scores)
+
+        loss = F.binary_cross_entropy_with_logits(scores, labs, reduction="none")
+        loss = loss * loss_mask
+
+        length, width = scores.shape[-2:]
+        starts = torch.arange(length, device=scores.device).unsqueeze(1)
+        offsets = torch.arange(width, device=scores.device).unsqueeze(0)
+        valid = (starts + offsets) < length
+        loss = loss * valid.unsqueeze(0).unsqueeze(0).to(loss.dtype)
+        return loss.sum()
 
     def compute_struct_loss(
             self,
@@ -750,14 +895,16 @@ class SpanExtractorModel(BaseExtractorModel):
     def compile(self) -> 'Extractor':
         """Compile tensor subgraphs with ``torch.compile(dynamic=True)``.
 
-        Three components are compiled (all verified 0 graph breaks):
+        Four components are compiled:
 
         - **encoder** (DeBERTa backbone)
-        - **_compute_span_rep_core** (span index + MLP)
+        - **_compute_span_rep_core** (legacy span index + MLP)
+        - **_compute_span_scores_core** (factorized direct span scoring)
         - **count_embed** (CompileSafeGRU + DownscaledTransformer)
 
-        The list-of-tensors padding in ``compute_span_rep_batched`` and the
-        per-sample Python decode path are left in eager mode.
+        The list-of-tensors padding in ``compute_span_rep_batched`` /
+        ``compute_span_scores_batched`` and the per-sample Python decode path
+        are left in eager mode.
 
         The first call triggers tracing and is slow; subsequent calls
         with similar shapes use the cached compiled graph.
@@ -775,8 +922,13 @@ class SpanExtractorModel(BaseExtractorModel):
         self._compute_span_rep_core = torch.compile(
             self._compute_span_rep_core, dynamic=True,
         )
+        self._compute_span_scores_core = torch.compile(
+            self._compute_span_scores_core, dynamic=True,
+        )
         self.count_embed = torch.compile(self.count_embed, dynamic=True)
-        logger.info("Compiled encoder, span-rep, and count-embed with torch.compile(dynamic=True)")
+        logger.info(
+            "Compiled encoder, span-rep/direct-score, and count-embed with torch.compile(dynamic=True)"
+        )
         return self
 
     # =========================================================================

--- a/tests/test_direct_span_scoring.py
+++ b/tests/test_direct_span_scoring.py
@@ -1,0 +1,239 @@
+import torch
+
+from gliner2.layers import SpanMarkerV0
+
+
+def _safe_spans(batch_size: int, length: int, max_width: int, device):
+    starts = torch.arange(length, device=device).unsqueeze(1).expand(-1, max_width)
+    widths = torch.arange(max_width, device=device).unsqueeze(0)
+    ends = starts + widths
+    valid = ends < length
+    starts = starts.reshape(-1).unsqueeze(0).expand(batch_size, -1)
+    ends = ends.reshape(-1).unsqueeze(0).expand(batch_size, -1)
+    valid_flat = valid.reshape(-1).unsqueeze(0).expand(batch_size, -1)
+    spans = torch.stack(
+        [
+            torch.where(valid_flat, starts, torch.zeros_like(starts)),
+            torch.where(valid_flat, ends, torch.zeros_like(ends)),
+        ],
+        dim=-1,
+    )
+    return spans, valid
+
+
+def _reference_scores(layer, hidden, queries):
+    batch, length, _ = hidden.shape
+    spans, valid = _safe_spans(batch, length, layer.max_width, hidden.device)
+    span_rep = layer(hidden, spans)
+    scores = torch.einsum("blwh,bqh->bqlw", span_rep, queries)
+    return scores, valid
+
+
+def test_direct_span_scores_match_reference_fp32_eval():
+    torch.manual_seed(7)
+    layer = SpanMarkerV0(hidden_size=128, max_width=8, dropout=0.1).eval()
+    hidden = torch.randn(3, 61, 128)
+    queries = torch.randn(3, 9, 128)
+
+    with torch.inference_mode():
+        reference, _ = _reference_scores(layer, hidden, queries)
+        direct = layer.score_queries(hidden, queries)
+
+    valid = torch.isfinite(direct)
+    torch.testing.assert_close(direct[valid], reference[valid], rtol=2e-5, atol=2e-5)
+
+
+def test_direct_span_scores_respect_variable_lengths():
+    torch.manual_seed(11)
+    layer = SpanMarkerV0(hidden_size=96, max_width=8, dropout=0.1).eval()
+    hidden = torch.randn(3, 64, 96)
+    queries = torch.randn(3, 5, 96)
+    lengths = torch.tensor([64, 37, 13])
+
+    with torch.inference_mode():
+        direct = layer.score_queries(hidden, queries, lengths)
+        for i, length in enumerate(lengths.tolist()):
+            reference, _ = _reference_scores(
+                layer, hidden[i:i + 1, :length], queries[i:i + 1]
+            )
+            current = direct[i:i + 1, :, :length]
+            valid = torch.isfinite(current)
+            torch.testing.assert_close(
+                current[valid], reference[valid], rtol=2e-5, atol=2e-5
+            )
+            assert not torch.isfinite(direct[i, :, length:]).any()
+
+
+def test_direct_span_scores_preserve_training_dropout_location():
+    torch.manual_seed(17)
+    layer = SpanMarkerV0(hidden_size=64, max_width=4, dropout=0.1).train()
+    hidden = torch.randn(2, 23, 64)
+    queries = torch.randn(2, 6, 64)
+
+    torch.manual_seed(1234)
+    reference, valid_2d = _reference_scores(layer, hidden, queries)
+    torch.manual_seed(1234)
+    direct = layer.score_queries(hidden, queries, mask_invalid=False)
+
+    valid = valid_2d[None, None].expand_as(reference)
+    torch.testing.assert_close(
+        direct[valid], reference[valid], rtol=3e-5, atol=3e-5
+    )
+
+
+def test_direct_span_scores_match_training_gradients():
+    """Factorized training preserves valid-span gradients with the same dropout mask."""
+    torch.manual_seed(23)
+    layer = SpanMarkerV0(hidden_size=48, max_width=4, dropout=0.1).train()
+    hidden_base = torch.randn(2, 19, 48)
+    queries_base = torch.randn(2, 5, 48)
+
+    hidden_ref = hidden_base.detach().clone().requires_grad_(True)
+    queries_ref = queries_base.detach().clone().requires_grad_(True)
+    torch.manual_seed(4321)
+    reference, valid_2d = _reference_scores(layer, hidden_ref, queries_ref)
+    valid = valid_2d[None, None].expand_as(reference)
+    reference_loss = reference[valid].square().mean()
+    reference_loss.backward()
+
+    ref_hidden_grad = hidden_ref.grad.detach().clone()
+    ref_query_grad = queries_ref.grad.detach().clone()
+    ref_param_grads = {
+        name: param.grad.detach().clone()
+        for name, param in layer.named_parameters()
+        if param.grad is not None
+    }
+
+    layer.zero_grad(set_to_none=True)
+    hidden_direct = hidden_base.detach().clone().requires_grad_(True)
+    queries_direct = queries_base.detach().clone().requires_grad_(True)
+    torch.manual_seed(4321)
+    direct = layer.score_queries(
+        hidden_direct, queries_direct, mask_invalid=False
+    )
+    direct_loss = direct[valid].square().mean()
+    direct_loss.backward()
+
+    torch.testing.assert_close(direct_loss, reference_loss, rtol=5e-5, atol=5e-6)
+    torch.testing.assert_close(
+        hidden_direct.grad, ref_hidden_grad, rtol=2e-4, atol=2e-6
+    )
+    torch.testing.assert_close(
+        queries_direct.grad, ref_query_grad, rtol=2e-4, atol=2e-6
+    )
+    for name, param in layer.named_parameters():
+        if name not in ref_param_grads:
+            continue
+        assert param.grad is not None
+        torch.testing.assert_close(
+            param.grad, ref_param_grads[name], rtol=3e-4, atol=3e-6
+        )
+
+
+def test_direct_structure_loss_matches_legacy_without_dropout(tiny_span_model):
+    """Direct raw logits reproduce the legacy structure loss exactly up to FP noise."""
+    model = tiny_span_model.eval()
+    hidden = model.hidden_size
+    token_embeddings = torch.randn(17, hidden)
+    schema_emb = torch.randn(4, hidden)  # [P] + three fields
+    structure = [
+        2,
+        [
+            [(1, 2), (4, 4), (7, 8)],
+            [(2, 3), None, [(9, 9), (11, 12)]],
+        ],
+    ]
+
+    with torch.no_grad():
+        span_info = model.compute_span_rep(token_embeddings)
+        legacy_loss = model.compute_struct_loss(
+            span_info["span_rep"],
+            schema_emb,
+            structure,
+            span_info["span_mask"],
+            masking_rate=0.0,
+        )
+
+        gold_count = min(structure[0], 19)
+        projected = model.count_embed(schema_emb[1:], gold_count)
+        count_dim, field_dim, hidden_dim = projected.shape
+        direct = model.compute_span_scores_batched(
+            [token_embeddings],
+            [projected.reshape(count_dim * field_dim, hidden_dim)],
+            mask_invalid=False,
+        )[0].reshape(count_dim, field_dim, len(token_embeddings), model.max_width)
+        direct_loss = model.compute_struct_loss_from_scores(
+            direct, structure, masking_rate=0.0
+        )
+
+    torch.testing.assert_close(direct_loss, legacy_loss, rtol=2e-5, atol=2e-5)
+
+
+def test_training_forward_uses_direct_span_scoring(tiny_span_model, monkeypatch):
+    """Training must not fall back to legacy span-representation materialization."""
+    from gliner2.training.data import InputExample, Relation, Structure
+    from gliner2.training.trainer import ExtractorCollator, ExtractorDataset
+
+    examples = [
+        InputExample(
+            text="Apple hired Tim Cook in Cupertino.",
+            entities={"company": ["Apple"], "person": ["Tim Cook"]},
+            structures=[Structure("employment", company="Apple", person="Tim Cook")],
+            relations=[Relation("works_for", head="Tim Cook", tail="Apple")],
+        ),
+        InputExample(
+            text="Google hired Jane Smith in London.",
+            entities={"company": ["Google"], "person": ["Jane Smith"]},
+            structures=[Structure("employment", company="Google", person="Jane Smith")],
+            relations=[Relation("works_for", head="Jane Smith", tail="Google")],
+        ),
+    ]
+    dataset = ExtractorDataset.from_examples(examples, shuffle=False, validate=True)
+    collator = ExtractorCollator(
+        tiny_span_model.processor,
+        is_training=True,
+        architecture=tiny_span_model.architecture,
+    )
+    batch = collator([dataset[0], dataset[1]])
+
+    def _legacy_path_forbidden(*args, **kwargs):
+        raise AssertionError("legacy span representation path was called")
+
+    monkeypatch.setattr(tiny_span_model, "compute_span_rep_batched", _legacy_path_forbidden)
+    monkeypatch.setattr(tiny_span_model, "compute_span_rep", _legacy_path_forbidden)
+
+    tiny_span_model.train()
+    out = tiny_span_model(batch)
+    assert torch.isfinite(out["total_loss"])
+    assert torch.isfinite(out["structure_loss"])
+    out["total_loss"].backward()
+
+    span_grads = [
+        p.grad for p in tiny_span_model.span_rep.parameters()
+        if p.requires_grad
+    ]
+    assert any(g is not None and torch.isfinite(g).all() and g.abs().sum() > 0 for g in span_grads)
+
+
+def test_mixed_inference_uses_direct_span_scoring(tiny_span_model, monkeypatch):
+    """Entities, structures, relations and classifications share the direct path."""
+    model = tiny_span_model.eval()
+    schema = model.create_schema()
+    schema.entities(["company", "person", "location"])
+    schema.classification("sentiment", ["positive", "negative"])
+    schema.structure("employment").field("person").field("company")
+    schema.relations(["works_for"])
+
+    def _legacy_path_forbidden(*args, **kwargs):
+        raise AssertionError("legacy span representation path was called")
+
+    monkeypatch.setattr(model, "compute_span_rep_batched", _legacy_path_forbidden)
+    monkeypatch.setattr(model, "compute_span_rep", _legacy_path_forbidden)
+
+    result = model.extract(
+        "Tim Cook works for Apple in Cupertino.",
+        schema,
+        include_confidence=True,
+        include_spans=True,
+    )
+    assert isinstance(result, dict)


### PR DESCRIPTION
## Summary

- Avoid materializing the final dense `[B, L, W, H]` span representation during scoring.
- Factor the span MLP into token-side start/end projections and a query-side final projection.
- Use padded `unfold`, broadcasted start states, and `torch.baddbmm` for direct span/query scoring.
- Use the same path for entities, structures, relations, mixed schemas, Joint IE, and training.
- No checkpoint, config, or public API changes.

## Why

The current path applies the output MLP independently to every candidate span, even though spans reuse the same start/end token states.

For the final span projection,

```text
qᵀ(W₂r + b₂) = (W₂ᵀq)ᵀr + qᵀb₂
```

so the start/end projections can be computed once per token and the final projection can be folded into the query vectors. This removes the final dense span representation from the scoring path.

Training keeps the same ReLU/dropout placement and applies the existing validity mask after BCE.

## Benchmark

Benchmark script: `benchmarks/benchmark_direct_span_full.py`

### Setup

```text
CPU:            Intel Core i9-12900KS
GPU:            NVIDIA RTX A5000, 24 GB
RAM:            64 GB
OS:             Ubuntu 22.04.5 LTS
NVIDIA driver:  535.309.01
CUDA:           12.6

Python:         3.12
PyTorch:        2.13.0+cu126
Transformers:   5.15.1
Model:          fastino/gliner2-base-v1
Precision:      FP16, FP32
torch.compile:  disabled

Legacy commit:
a91fd1d2c72debe43907296c8e375a036c6a4faf
```

Legacy and current run in separate processes with identical benchmark corpora and fixed Python, NumPy, PyTorch, CUDA, and `PYTHONHASHSEED` seeds. Timings are the median of 3 runs after warmup.

### End-to-end inference

Batch size 8:

| Task | FP16 legacy → current | FP16 | FP32 legacy → current | FP32 |
|---|---:|---:|---:|---:|
| Entities | 99.59 → 102.94 docs/s | **1.034x** | 48.62 → 54.73 docs/s | **1.126x** |
| Structures | 94.59 → 99.35 docs/s | **1.050x** | 46.75 → 52.59 docs/s | **1.125x** |
| Relations | 85.47 → 91.45 docs/s | **1.070x** | 43.93 → 49.94 docs/s | **1.137x** |
| Mixed | 66.69 → 71.76 docs/s | **1.076x** | 36.15 → 40.79 docs/s | **1.128x** |
| Joint scoring | 110.94 → 123.20 docs/s | **1.110x** | 47.96 → 57.60 docs/s | **1.201x** |

Peak memory also drops on the larger inference workloads. For FP32 Joint scoring at batch size 8:

```text
1802.6 MiB -> 1532.7 MiB
```

### Controlled L / Q scaling

128 documents per point. `L` is text token length and `Q` is the number of span queries.

| L | Q | B | FP16 speedup | FP32 speedup |
|---:|---:|---:|---:|---:|
| 64 | 1 | 1 | 1.007x | 1.029x |
| 64 | 1 | 8 | 0.997x | 1.072x |
| 64 | 8 | 1 | 1.008x | 1.010x |
| 64 | 8 | 8 | 1.006x | 1.023x |
| 64 | 32 | 1 | 1.003x | 0.994x |
| 64 | 32 | 8 | 1.003x | 0.998x |
| 256 | 1 | 1 | 1.016x | 1.070x |
| 256 | 1 | 8 | 1.017x | **1.115x** |
| 256 | 8 | 1 | 1.014x | 1.082x |
| 256 | 8 | 8 | **1.034x** | **1.095x** |
| 256 | 32 | 1 | 1.004x | 1.047x |
| 256 | 32 | 8 | 1.015x | 1.062x |

The gain is larger for longer sequences and larger batches. At very short sequences the encoder/runtime overhead dominates, especially in FP16.

### Training

Forward + backward through the real training path:

| dtype | B | legacy | current | speedup | peak memory legacy → current | total loss abs. diff |
|---|---:|---:|---:|---:|---:|---:|
| FP16 | 1 | 47.26 samples/s | 48.48 samples/s | **1.026x** | 833.0 → 833.0 MiB | 9.28e-4 |
| FP16 | 8 | 119.34 samples/s | 127.37 samples/s | **1.067x** | 1202.2 → 1206.8 MiB | 3.31e-3 |
| FP32 | 1 | 38.59 samples/s | 39.94 samples/s | **1.035x** | 1616.9 → 1617.5 MiB | 0.0 |
| FP32 | 8 | 73.69 samples/s | 81.56 samples/s | **1.107x** | 2283.4 → 2281.5 MiB | 0.0 |

For FP32 B=8, `count_loss`, `classification_loss`, `structure_loss`, and `total_loss` are identical in the deterministic comparison. FP16 differences are limited to the expected half-precision reassociation in the span path.

### Output parity

- FP32 matches legacy outputs across all tested entities, structures, relations, mixed, and Joint IE cases.
- FP16 matches the legacy outputs at the default `0.5` threshold across all tested tasks; only a few threshold-edge differences appear at lower thresholds.
- Confidence differences are at normal FP16/FP32 numerical precision.

## Test plan

- [x] Direct span logits match legacy scoring within numerical tolerance
- [x] Training loss and gradient parity
- [x] Training uses the direct scoring path
- [x] Entity, structure, relation, mixed-schema, and Joint IE coverage
- [x] FP16 / FP32 CUDA benchmark against the exact legacy commit
- [x] `git diff --check`
